### PR TITLE
[Bugfix] new_filename injection

### DIFF
--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -461,6 +461,8 @@ except sqlite3.Error as error:
     sys.exit(1)
 
 # Looking for duplicate filename
+new_filename = new_filename.replace("'", "''")  # Fixing a bug whereby filenames with apostrophes would end the string prematurely, and would throw a syntax error
+                                                #when executing the query
 sqlite_query = "SELECT id FROM scenes WHERE path LIKE '%{}%';".format(new_filename)
 cursor.execute(sqlite_query)
 dupl_check = cursor.fetchall()


### PR DESCRIPTION
When new_filename has an apostrophe, executing sqlite_query throws a syntax error or executes whatever is after it when possible. 
This fixes it by escaping apostrophes on the filename.