### PR TITLE
[Hook Rename] Prevent rename db if file don't exist/failed

### DIFF
--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -479,9 +479,11 @@ if (os.path.isfile(current_path) == True):
             f.write("{}|{}|{}\n".format(FRAGMENT_SCENE_ID, current_path, new_path))
             f.close()
     else:
-        log.LogWarning("[OS] File failed to rename ? {}".format(new_path))
+        log.LogError("[OS] File failed to rename ? {}".format(new_path))
+        sys.exit(1)
 else:
-    log.LogWarning("[OS] File don't exist in your Disk/Drive ({})".format(current_path))
+    log.LogError("[OS] File don't exist in your Disk/Drive ({})".format(current_path))
+    sys.exit(1)
 
 # Database rename
 cursor.execute("UPDATE scenes SET path=? WHERE id=?;", [new_path, FRAGMENT_SCENE_ID])
@@ -492,3 +494,5 @@ sqliteConnection.close()
 log.LogInfo("[SQLITE] Database updated!")
 
 print("{'output':'Hook 'Update' Plugin finished.'}\n")
+
+# Last Updated July 02, 2021


### PR DESCRIPTION
My local version don't care if the file exist or not, but i think for most people it would be annoying that the rename don't work but rename the DB.