### PR TITLE
[renamerOnUpdate] Add scene rating and tags as fields + additional configurations

### DIFF
--- a/plugins/renamerOnUpdate/README.md
+++ b/plugins/renamerOnUpdate/README.md
@@ -1,6 +1,6 @@
 
 # SQLITE Renamer for Stash
-Using metadata from your Stash to rename your files.
+Using metadata from your Stash to rename your file.
 
 ## Requirement
 - Stash
@@ -13,7 +13,7 @@ Using metadata from your Stash to rename your files.
 - Download the whole folder 'renamerOnUpdate' (config.py, log.py, renamerOnUpdate.py/.yml)
 - Place it in your **plugins** folder (where the `config.yml` is)
 - Reload plugins (Settings > Plugins)
-- renamerOnUpdate should appears 
+- renamerOnUpdate appears 
 
 ### :exclamation: Make sure to configure the plugin by editing `config.py` before running it :exclamation:
 
@@ -26,7 +26,7 @@ Using metadata from your Stash to rename your files.
 
 ## Configuration
 
-- Read/Edit `config.py` for further information
+- Read/Edit `config.py`
 	- I recommend setting the **log_file** as it can be useful to revert.
 
 ### Example

--- a/plugins/renamerOnUpdate/README.md
+++ b/plugins/renamerOnUpdate/README.md
@@ -1,19 +1,19 @@
 
 # SQLITE Renamer for Stash
-Using metadata from your stash to rename your file.
+Using metadata from your Stash to rename your files.
 
 ## Requirement
 - Stash
 - Python 3+ (Tested on Python v3.9.1 64bit, Win10)
 - Request Module (https://pypi.org/project/requests/)
-- Windows 10 ? (No idea if this work for all OS)
+- Tested on Windows 10 and Synology/docker (No idea if this work for all OS)
 
 ## Installation
 
 - Download the whole folder 'renamerOnUpdate' (config.py, log.py, renamerOnUpdate.py/.yml)
 - Place it in your **plugins** folder (where the `config.yml` is)
 - Reload plugins (Settings > Plugins)
-- renamerOnUpdate should appear. 
+- renamerOnUpdate should appears 
 
 ### :exclamation: Make sure to configure the plugin by editing `config.py` before running it :exclamation:
 
@@ -26,7 +26,7 @@ Using metadata from your stash to rename your file.
 
 ## Configuration
 
-- Read/Edit `config.py`
+- Read/Edit `config.py` for further information
 	- I recommend setting the **log_file** as it can be useful to revert.
 
 ### Example
@@ -35,23 +35,30 @@ Using metadata from your stash to rename your file.
 
 The config will be:
 ```py
+
+# Change filename if the tag 'rename_tag' is present.
+tag_templates  = {
+	"rename_tag": "$year $title - $studio $resolution $video_codec",
+}
+
 # Change filename for scenes from 'Vixen' or 'Slayed' studio.
 studio_templates  = {
 	"Slayed": "$date $performer - $title [$studio]",
 	"Vixen": "$performer - $title [$studio]"
 }
-# Change filename if the tag 'rename_tag' is present.
-tag_templates  = {
-	"rename_tag": "$year $title - $studio $resolution $video_codec",
-}
+
 # Change filename no matter what
 use_default_template  =  True
+
 default_template  =  "$date $title"
+
 # Use space as a performer separator
 performer_splitchar  =  " "
+
 # If the scene has more than 3 performers, the $performer field will be ignored.
 performer_limit  =  3
 ```
+
 The scene was just scanned, everything is default (Title = Filename).
 
 Current filename: `Slayed.21.09.02.Ariana.Marie.Emily.Willis.And.Eliza.Ibarra.XXX.1080p.mp4`
@@ -66,4 +73,3 @@ Current filename: `Slayed.21.09.02.Ariana.Marie.Emily.Willis.And.Eliza.Ibarra.XX
 | ~Studio | **Slayed**| `2021-09-02 Ariana Marie Emily Willis Eliza Ibarra - Driver [Slayed].mp4` | studio_templates [Slayed]
 | +Performer | **Elsa Jean**| `2021-09-02 Driver [Slayed].mp4` | studio_templates [Slayed]<br>**Reach performer_limit**.
 | +Tag | **rename_tag**| `2021 Driver - Slayed HD h264.mp4` | tag_templates [rename_tag]
-

--- a/plugins/renamerOnUpdate/config.py
+++ b/plugins/renamerOnUpdate/config.py
@@ -11,6 +11,7 @@
 #   $studio 
 #   $parent_studio 
 #   $studio_family 
+#   $rating
 #   $video_codec 
 #   $audio_codec
 #
@@ -77,10 +78,18 @@ performer_ignore_male = False
 # 2016 Dani Daniels - Dani Daniels in ***.mp4 --> 2016 Dani Daniels in ***.mp4
 prevent_title_performer = False
 
+# Rating indicator option to identify the number correctly in your OS file search
+# Separated from the template handling above to avoid having only "RTG" in the filename for scenes without ratings
+# e. g.:
+# "{}" with scene rating of 5       == 5
+# "RTG{}" with scene rating of 5    == RTG5
+# "{}-stars" with scene rating 3    == 3-stars
+rating_format = "{}"
+
 # Only rename 'Organized' scenes.
 only_organized = False
 # Field to remove if the path is too long. First in list will be removed then second then ... if length is still too long.
-order_field = ["$video_codec", "$audio_codec", "$resolution", "$height", "$studio_family", "$studio", "$parent_studio", "$performer"]
+order_field = ["$video_codec", "$audio_codec", "$resolution", "rating", "$height", "$studio_family", "$studio", "$parent_studio", "$performer"]
 # Alternate way to show diff. Not useful at all.
 alt_diff_display = False
 

--- a/plugins/renamerOnUpdate/config.py
+++ b/plugins/renamerOnUpdate/config.py
@@ -67,6 +67,13 @@ log_file = r""
 ######################################
 #               Settings             #
 
+# Character which replaces every space in the filename
+# Common values are "." and "_"
+# e. g.:
+# "."
+# 2016-12-29.Eva.Lovia.-.Her.Fantasy.Ball
+filename_splitchar = " "
+
 # Character to use as a performer separator.
 performer_splitchar = " "
 # Maximum number of performer names in the filename. If there are more than that in a scene the filename will not include any performer name!
@@ -107,7 +114,7 @@ tags_blacklist = [
 # Only rename 'Organized' scenes.
 only_organized = False
 # Field to remove if the path is too long. First in list will be removed then second then ... if length is still too long.
-order_field = ["$video_codec", "$audio_codec", "$resolution", "rating", "$height", "$studio_family", "$studio", "$parent_studio", "$performer"]
+order_field = ["$video_codec", "$audio_codec", "$resolution", "tags", "rating", "$height", "$studio_family", "$studio", "$parent_studio", "$performer"]
 # Alternate way to show diff. Not useful at all.
 alt_diff_display = False
 

--- a/plugins/renamerOnUpdate/config.py
+++ b/plugins/renamerOnUpdate/config.py
@@ -1,40 +1,56 @@
 ###################################################################
-#
+#       General information         #
 # -----------------------------------------------------------------
-# Available: $date $year $performer $title $height $resolution $studio $parent_studio $studio_family $video_codec $audio_codec
-# -note:
-# $studio_family: If parent studio exist use it, else use the studio name.
-# $performer: If more than * performers, this field will be ignored. Limit to fix at Settings section below (default: 3)
+# Available elements for renaming:
+#   $date 
+#   $year 
+#   $performer 
+#   $title 
+#   $height 
+#   $resolution 
+#   $studio 
+#   $parent_studio 
+#   $studio_family 
+#   $video_codec 
+#   $audio_codec
+#
+# Note:
+# $studio_family: If parent studio exists use it, else use the studio name.
+# $performer: If more than * performers linked to the scene, this field will be ignored. Limit this number at Settings section below (default: 3)
 # $resolution: SD/HD/UHD/VERTICAL (for phone) | $height: 720p 1080p 4k 8k
 # -----------------------------------------------------------------
-# e.g.:
+# Example templates:
+# 
 # $title                                    == Her Fantasy Ball
 # $date $title                              == 2016-12-29 Her Fantasy Ball
+# $date.$title                              == 2016-12-29.Her Fantasy Ball
 # $year $title $height                      == 2016 Her Fantasy Ball 1080p
+# $year_$title-$height                      == 2016_Her Fantasy Ball-1080p
 # $date $performer - $title [$studio]       == 2016-12-29 Eva Lovia - Her Fantasy Ball [Sneaky Sex]
 # $parent_studio $date $performer - $title  == Reality Kings 2016-12-29 Eva Lovia - Her Fantasy Ball
 #
 ####################################################################
+
 #               TEMPLATE             #
 
 # Priority : Tags > Studios > Default
 
-# templates to use for given tags
-# add or remove as needed
+# Templates to use for given tags
+# Add or remove as needed or leave it empty/comment out
 tag_templates = {
-    "!1. Western": "$date $performer - $title [$studio]",
-    "!1. JAV": "$title",
-    "!1. Anime": "$title $date [$studio]"
+    # "!1. Western": "$date $performer - $title [$studio]",
+    # "!1. JAV": "$title",
+    # "!1. Anime": "$title $date [$studio]"
 }
 
-# adjust the below if you want to use studio names instead of tags for the renaming templates
+# Adjust the below if you want to use studio names instead of tags for the renaming templates
 studio_templates = {
 
 }
 
-# change to True to use the default template if no specific tag/studio is found
+# Change to True to use the default template if no specific tag/studio is found
 use_default_template = False
-# default template, adjust as needed
+# Default template, adjust as needed
 default_template = "$date $title"
 
 ######################################
@@ -50,9 +66,9 @@ log_file = r""
 
 # Character to use as a performer separator.
 performer_splitchar = " "
-# Maximum number of performer names in the filename. If there are more than that in a scene the filename will not include any performer names!
+# Maximum number of performer names in the filename. If there are more than that in a scene the filename will not include any performer name!
 performer_limit = 3
-# ignore male performers.
+# Ignore male performers.
 performer_ignore_male = False
 
 # If $performer is before $title, prevent having duplicate text. 
@@ -64,7 +80,7 @@ prevent_title_performer = False
 # Only rename 'Organized' scenes.
 only_organized = False
 # Field to remove if the path is too long. First in list will be removed then second then ... if length is still too long.
-order_field = ["$video_codec", "$audio_codec", "$resolution", "$height", "$studio_family", "$studio", "$parent_studio","$performer"]
+order_field = ["$video_codec", "$audio_codec", "$resolution", "$height", "$studio_family", "$studio", "$parent_studio", "$performer"]
 # Alternate way to show diff. Not useful at all.
 alt_diff_display = False
 

--- a/plugins/renamerOnUpdate/config.py
+++ b/plugins/renamerOnUpdate/config.py
@@ -87,6 +87,12 @@ performer_ignore_male = False
 # 2016 Dani Daniels - Dani Daniels in ***.mp4 --> 2016 Dani Daniels in ***.mp4
 prevent_title_performer = False
 
+# Squeeze studio names removes all spaces in studio, parent studio and studio family name
+# e. g.:
+# Reality Kings --> RealityKings
+# Team Skeet Extras --> TeamSkeetExtras
+squeeze_studio_names = False
+
 # Rating indicator option to identify the number correctly in your OS file search
 # Separated from the template handling above to avoid having only "RTG" in the filename for scenes without ratings
 # e. g.:

--- a/plugins/renamerOnUpdate/config.py
+++ b/plugins/renamerOnUpdate/config.py
@@ -12,6 +12,7 @@
 #   $parent_studio 
 #   $studio_family 
 #   $rating
+#   $tags
 #   $video_codec 
 #   $audio_codec
 #
@@ -29,6 +30,7 @@
 # $year_$title-$height                      == 2016_Her Fantasy Ball-1080p
 # $date $performer - $title [$studio]       == 2016-12-29 Eva Lovia - Her Fantasy Ball [Sneaky Sex]
 # $parent_studio $date $performer - $title  == Reality Kings 2016-12-29 Eva Lovia - Her Fantasy Ball
+# $date $title - $tags                      == 2016-12-29 Her Fantasy Ball - Blowjob Cumshot Facial Tattoo
 #
 ####################################################################
 
@@ -85,6 +87,22 @@ prevent_title_performer = False
 # "RTG{}" with scene rating of 5    == RTG5
 # "{}-stars" with scene rating 3    == 3-stars
 rating_format = "{}"
+
+# Character to use as a tag separator.
+tags_splitchar = " "
+# Include and exclude tags
+# 	Tags will be compared strictly. "pantyhose" != "Pantyhose" and "panty hose" != "pantyhose"
+# Option 1: If you're using whitelist, every other tag which is not listed there will be ignored in the filename
+# Option 2: All tags in the tags_blacklist array will be ignored in the filename. Every other tag will be used.
+# Option 3: Leave both arrays empty if you're looking for every tag which is linked to the scene. 
+# 			Attention: Only recommended if the scene linked tags number is not that big due to maxiumum filename length
+tags_whitelist = [
+    # "Brunette", "Blowjob"
+]
+
+tags_blacklist = [
+	# ignored tags...
+]
 
 # Only rename 'Organized' scenes.
 only_organized = False

--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -263,6 +263,8 @@ PERFORMER_LIMIT = config.performer_limit
 PERFORMER_IGNORE_MALE = config.performer_ignore_male
 PREVENT_TITLE_PERF = config.prevent_title_performer
 
+SQUEEZE_STUDIO_NAMES = config.squeeze_studio_names
+
 RATING_FORMAT = config.rating_format
 
 TAGS_SPLITCHAR = config.tags_splitchar
@@ -351,11 +353,17 @@ if STASH_SCENE.get("performers"):
 
 # Grab Studio name
 if STASH_SCENE.get("studio"):
-    scene_information["studio"] = STASH_SCENE["studio"].get("name")
+    if SQUEEZE_STUDIO_NAMES:
+        scene_information["studio"] = STASH_SCENE["studio"].get("name").replace(' ', '')
+    else:
+        scene_information["studio"] = STASH_SCENE["studio"].get("name")
     scene_information["studio_family"] = scene_information["studio"]
     # Grab Parent name
     if STASH_SCENE["studio"].get("parent_studio"):
-        scene_information["parent_studio"] = STASH_SCENE["studio"]["parent_studio"]["name"]
+        if SQUEEZE_STUDIO_NAMES:
+            scene_information["parent_studio"] = STASH_SCENE["studio"]["parent_studio"]["name"].replace(' ', '')
+        else:
+            scene_information["parent_studio"] = STASH_SCENE["studio"]["parent_studio"]["name"]
         scene_information["studio_family"] = scene_information["parent_studio"]
 
 # Grab Tags

--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -190,6 +190,8 @@ def makeFilename(scene_information, query):
     new_filename = re.sub('(?:[\s_]-){2,}', ' -', new_filename)
     # Remove space at start/end
     new_filename = new_filename.strip(" -")
+    # Replace spaces with splitchar
+    new_filename = new_filename.replace(' ', FILENAME_SPLITCHAR)
     return new_filename
 
 
@@ -254,6 +256,7 @@ filename_template = None
 
 # READING CONFIG
 
+FILENAME_SPLITCHAR = config.filename_splitchar
 
 PERFORMER_SPLITCHAR = config.performer_splitchar
 PERFORMER_LIMIT = config.performer_limit

--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -104,6 +104,7 @@ def graphql_getScene(scene_id):
         id
         title
         date
+        rating
         organized
         path
         file {
@@ -243,7 +244,7 @@ LOGFILE = config.log_file
 STASH_SCENE = graphql_getScene(FRAGMENT_SCENE_ID)
 STASH_CONFIG = graphql_getConfiguration()
 STASH_DATABASE = STASH_CONFIG["general"]["databasePath"]
-TEMPLATE_FIELD = "$date $year $performer $title $height $resolution $studio $parent_studio $studio_family $video_codec $audio_codec".split(" ")
+TEMPLATE_FIELD = "$date $year $performer $title $height $resolution $studio $parent_studio $studio_family $rating $video_codec $audio_codec".split(" ")
 
 #log.LogDebug("Scene ID: {}".format(FRAGMENT_SCENE_ID))
 #log.LogDebug("Scene Info: {}".format(STASH_SCENE))
@@ -258,6 +259,8 @@ PERFORMER_SPLITCHAR = config.performer_splitchar
 PERFORMER_LIMIT = config.performer_limit
 PERFORMER_IGNORE_MALE = config.performer_ignore_male
 PREVENT_TITLE_PERF = config.prevent_title_performer
+
+RATING_FORMAT = config.rating_format
 
 PROCESS_KILL = config.process_kill_attach
 PROCESS_ALLRESULT = config.process_getall
@@ -319,6 +322,10 @@ if STASH_SCENE.get("title"):
 # Grab Date
 scene_information["date"] = STASH_SCENE.get("date")
 
+# Grab Rating
+if STASH_SCENE.get("rating"):
+    scene_information["rating"] = RATING_FORMAT.format(STASH_SCENE["rating"])
+
 # Grab Performer
 if STASH_SCENE.get("performers"):
     perf_list = ""
@@ -358,6 +365,7 @@ if STASH_SCENE["file"]["height"] >= 4320:
 if STASH_SCENE["file"]["height"] > STASH_SCENE["file"]["width"]:
     scene_information["resolution"] = 'VERTICAL'
 
+# Grab Video and Audio codec
 scene_information["video_codec"] = STASH_SCENE["file"]["video_codec"]
 scene_information["audio_codec"] = STASH_SCENE["file"]["audio_codec"]
 

--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -244,7 +244,7 @@ LOGFILE = config.log_file
 STASH_SCENE = graphql_getScene(FRAGMENT_SCENE_ID)
 STASH_CONFIG = graphql_getConfiguration()
 STASH_DATABASE = STASH_CONFIG["general"]["databasePath"]
-TEMPLATE_FIELD = "$date $year $performer $title $height $resolution $studio $parent_studio $studio_family $rating $video_codec $audio_codec".split(" ")
+TEMPLATE_FIELD = "$date $year $performer $title $height $resolution $studio $parent_studio $studio_family $rating $tags $video_codec $audio_codec".split(" ")
 
 #log.LogDebug("Scene ID: {}".format(FRAGMENT_SCENE_ID))
 #log.LogDebug("Scene Info: {}".format(STASH_SCENE))
@@ -261,6 +261,10 @@ PERFORMER_IGNORE_MALE = config.performer_ignore_male
 PREVENT_TITLE_PERF = config.prevent_title_performer
 
 RATING_FORMAT = config.rating_format
+
+TAGS_SPLITCHAR = config.tags_splitchar
+TAGS_WHITELIST = config.tags_whitelist
+TAGS_BLACKLIST = config.tags_blacklist
 
 PROCESS_KILL = config.process_kill_attach
 PROCESS_ALLRESULT = config.process_getall
@@ -350,6 +354,26 @@ if STASH_SCENE.get("studio"):
     if STASH_SCENE["studio"].get("parent_studio"):
         scene_information["parent_studio"] = STASH_SCENE["studio"]["parent_studio"]["name"]
         scene_information["studio_family"] = scene_information["parent_studio"]
+
+# Grab Tags
+if STASH_SCENE.get("tags"):
+    tag_list = ""
+    for tag in STASH_SCENE["tags"]:
+        if tag["name"]:
+            if tag["name"] in TAGS_BLACKLIST:
+                continue
+            else:
+                if len(TAGS_WHITELIST) > 0:
+                    if tag["name"] in TAGS_WHITELIST:
+                        tag_list += tag["name"] + TAGS_SPLITCHAR
+                    else:
+                        continue
+                else:
+                    tag_list += tag["name"] + TAGS_SPLITCHAR   
+        else:
+            continue
+    tag_list = tag_list[:-len(TAGS_SPLITCHAR)]
+    scene_information["tags"] = tag_list
 
 # Grab Height (720p,1080p,4k...)
 scene_information["resolution"] = 'SD'

--- a/plugins/renamerOnUpdate/renamerOnUpdate.yml
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.yml
@@ -1,7 +1,7 @@
 name: renamerOnUpdate
-description: Rename filename based on a template.
+description: Rename filenames based on a template.
 url: https://github.com/stashapp/CommunityScripts
-version: 1.3
+version: 1.4
 exec:
   - python
   - "{pluginDir}/renamerOnUpdate.py"

--- a/plugins/renamerOnUpdate/renamerOnUpdate.yml
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.yml
@@ -1,5 +1,5 @@
 name: renamerOnUpdate
-description: Rename filenames based on a template.
+description: Rename filename based on a template.
 url: https://github.com/stashapp/CommunityScripts
 version: 1.4
 exec:
@@ -8,6 +8,6 @@ exec:
 interface: raw
 hooks:
   - name: hook_rename
-    description: Rename files when you update a scene.
+    description: Rename file when you update a scene.
     triggeredBy: 
       - Scene.Update.Post


### PR DESCRIPTION
Add new filename fields:
- scene rating with pre or post string options (e. g.: 'RTG5')
- tags list to add all linked tags included/excluded by whitelist and blacklist

New configurations:
- Replace spaces with another character (e. g.: gain period separated filenames)
- Squeeze studio names 