### PR TITLE
[renameonUpdate] Fix studio_family

### DIFF
--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -246,7 +246,7 @@ LOGFILE = config.log_file
 STASH_SCENE = graphql_getScene(FRAGMENT_SCENE_ID)
 STASH_CONFIG = graphql_getConfiguration()
 STASH_DATABASE = STASH_CONFIG["general"]["databasePath"]
-TEMPLATE_FIELD = "$date $year $performer $title $height $resolution $studio $parent_studio $studio_family $rating $tags $video_codec $audio_codec".split(" ")
+TEMPLATE_FIELD = "$date $year $performer $title $height $resolution $parent_studio $studio_family $studio $rating $tags $video_codec $audio_codec".split(" ")
 
 #log.LogDebug("Scene ID: {}".format(FRAGMENT_SCENE_ID))
 #log.LogDebug("Scene Info: {}".format(STASH_SCENE))

--- a/plugins/renamerOnUpdate/renamerOnUpdate.yml
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.yml
@@ -1,7 +1,7 @@
 name: renamerOnUpdate
 description: Rename filename based on a template.
 url: https://github.com/stashapp/CommunityScripts
-version: 1.4
+version: 1.41
 exec:
   - python
   - "{pluginDir}/renamerOnUpdate.py"


### PR DESCRIPTION
Because `$studio` was before `$studio_family` it removed the `$studio` part
This fix it.