### PR TITLE
[renamerOnUpdate] Search recursively for parent studio template

### DIFF
--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -295,12 +295,17 @@ if config.use_default_template:
 
 # Change by Studio
 if STASH_SCENE.get("studio") and config.studio_templates:
-    if config.studio_templates.get(STASH_SCENE["studio"]["name"]):
-        filename_template = config.studio_templates[STASH_SCENE["studio"]["name"]]
-    # by Parent
-    if STASH_SCENE["studio"].get("parent_studio"):
-        if config.studio_templates.get(STASH_SCENE["studio"]["name"]):
-            filename_template = config.studio_templates[STASH_SCENE["studio"]["name"]]
+    template_found = False
+    current_studio = STASH_SCENE.get("studio")
+    if config.studio_templates.get(current_studio["name"]):
+        filename_template = config.studio_templates[current_studio["name"]]
+        template_found = True
+    # by first Parent found
+    while current_studio.get("parent_studio") and not template_found:
+        if config.studio_templates.get(current_studio.get("parent_studio").get("name")):
+            filename_template = config.studio_templates[current_studio["parent_studio"]["name"]]
+            template_found = True
+        current_studio = current_studio.get("parent_studio")
 
 # Change by Tag
 if STASH_SCENE.get("tags") and config.tag_templates:

--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -165,6 +165,26 @@ def graphql_getConfiguration():
     result = callGraphQL(query)
     return result.get('configuration')
 
+def graphql_getStudio(studio_id):
+    query = """
+        query FindStudio($id:ID!) {
+            findStudio(id: $id) {
+                id
+                name
+                parent_studio {
+                    id
+                    name
+                    aliases
+                }
+                aliases
+            }
+        }
+    """
+    variables = {
+        "id": studio_id
+    }
+    result = callGraphQL(query, variables)
+    return result.get("findStudio")
 
 def makeFilename(scene_information, query):
     new_filename = str(query)
@@ -305,7 +325,7 @@ if STASH_SCENE.get("studio") and config.studio_templates:
         if config.studio_templates.get(current_studio.get("parent_studio").get("name")):
             filename_template = config.studio_templates[current_studio["parent_studio"]["name"]]
             template_found = True
-        current_studio = current_studio.get("parent_studio")
+        current_studio = graphql_getStudio(current_studio.get("parent_studio")["id"])
 
 # Change by Tag
 if STASH_SCENE.get("tags") and config.tag_templates:

--- a/plugins/renamerOnUpdate/renamerOnUpdate.yml
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.yml
@@ -1,7 +1,7 @@
 name: renamerOnUpdate
 description: Rename filename based on a template.
 url: https://github.com/stashapp/CommunityScripts
-version: 1.41
+version: 1.43
 exec:
   - python
   - "{pluginDir}/renamerOnUpdate.py"


### PR DESCRIPTION
I noticed that the code at https://github.com/stashapp/CommunityScripts/blob/3a321a06c9fcaa4db8fe8c651a6577a85e3258a6/plugins/renamerOnUpdate/renamerOnUpdate.py#L301-L303 wasn't retrieving the template for the parent studio but the current studio.

I changed it so that it recursively searches for templates of parent studios BUT stops at the first template found. This makes it possible to have a different template for just a single subsidiary studio.  
The alternative would be to traverse all parent studios and take the highest one in the chain.