### PR TITLE
[renamer] Enforce utf-8 encoding when opening FILE_DRYRUN_RESULT

### DIFF
--- a/plugins/renamer/renamerTask.py
+++ b/plugins/renamer/renamerTask.py
@@ -602,7 +602,7 @@ if PLUGIN_ARGS in ["DRYRUN_full","Process_full"]:
 if PLUGIN_ARGS == "Process_dry":
     if os.path.exists(FILE_DRYRUN_RESULT):
         scenes = {"scenes":[]}
-        with open(FILE_DRYRUN_RESULT, 'r') as f:
+        with open(FILE_DRYRUN_RESULT, 'r', encoding='utf-8') as f:
             for line in f:
                 scene_id_file = line.split("|")[0]
                 scenes["scenes"].append({"id": scene_id_file})
@@ -628,7 +628,7 @@ if PLUGIN_ARGS == "Process_dry":
 if DRY_RUN:
     num_lines = 0
     if os.path.exists(FILE_DRYRUN_RESULT):
-        num_lines = sum(1 for _ in open(FILE_DRYRUN_RESULT))
+        num_lines = sum(1 for _ in open(FILE_DRYRUN_RESULT, encoding='utf-8'))
     if num_lines > 0:
         log.LogInfo("[DRY-RUN] There wil be {} file(s) changed. Check {} for more details".format(num_lines, FILE_DRYRUN_RESULT))
     else:


### PR DESCRIPTION
While running this on Windows I was getting an error due to a charset mismatch. The default encoding on Windows is not UTF-8 so, since we're using it while writing the file, we should make sure we're using it while reading the dry run file.