### PR TITLE
[renamer] Don't count male performers if they're being ignored

### DIFF
--- a/plugins/renamer/renamerTask.py
+++ b/plugins/renamer/renamerTask.py
@@ -399,18 +399,27 @@ def renamer(scene_id):
     # Grab Performer
     if STASH_SCENE.get("performers"):
         perf_list = ""
-        if len(STASH_SCENE["performers"]) > PERFORMER_LIMIT:
+        perf_count = 0
+
+        for perf in STASH_SCENE["performers"]:
+            #log.LogDebug(performer)
+            if PERFORMER_IGNORE_MALE and perf["gender"] == "MALE":
+                continue
+
+            if perf_count > PERFORMER_LIMIT:
+                # We've already exceeded the limit. No need to keep checking
+                break
+
+            perf_list += perf["name"] + PERFORMER_SPLITCHAR
+            perf_count += 1
+
+        # Remove last character
+        perf_list = perf_list[:-len(PERFORMER_SPLITCHAR)]
+
+        if perf_count > PERFORMER_LIMIT:
             log.LogInfo("More than {} performer(s). Ignoring $performer".format(PERFORMER_LIMIT))
-        else:
-            for perf in STASH_SCENE["performers"]:
-                #log.LogDebug(performer)
-                if PERFORMER_IGNORE_MALE:
-                    if perf["gender"] != "MALE":
-                        perf_list += perf["name"] + PERFORMER_SPLITCHAR
-                else:
-                    perf_list += perf["name"] + PERFORMER_SPLITCHAR
-            # Remove last character
-            perf_list = perf_list[:-len(PERFORMER_SPLITCHAR)]
+            perf_list = ""
+
         scene_information["performer"] = perf_list
 
     # Grab Studio name


### PR DESCRIPTION
Here's the scenario I was running into:

* Performer limit set to 5
* 5 female performers, 3 male performers
* `performer_ignore_male` in config set to `True`
* Renamer still skipped including performers in the new file name because the total performer count was greater than the limit

This seems counter-intuitive, so I'm proposing we change it to only count eligible performers.