### PR TITLE
[renamerOnUpdate] Add option to replace thing

### DIFF
--- a/plugins/renamerOnUpdate/config.py
+++ b/plugins/renamerOnUpdate/config.py
@@ -82,6 +82,15 @@ filename_splitchar = " "
 # replace space for stash field (title, performer...), if you have a title 'I love Stash' it can become 'I_love_Stash'
 field_whitespaceSeperator = ""
 
+# Match and replace. ("match": ["replace with", "system"])
+# the second element of the list determine the system used. If you don't put this element, the default is word
+# regex: match a regex, word: match a word, any: match a term
+# difference between 'word' & 'any': word is between seperator (space, _, -), any is anything ('ring' would replace 'during')
+# ex:   "Scene": ["Sc.", "word"]    - Replace Scene by Sc.
+#       r"S\d+:E\d+": ["", "regex"] - Remove Sxx:Ex (x is a digit)
+replace_words = {
+}
+
 # put the filename in lowercase
 lowercase_Filename = False
 # remove these characters if there are present in the filename

--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -265,9 +265,9 @@ def has_handle(fpath, all_result=False):
 
 def config_edit(name: str, state: bool):
     found = 0
-    with open(config.__file__, 'r') as file:
+    with open(config.__file__, 'r', encoding='utf8') as file:
         config_lines = file.readlines()
-    with open(config.__file__, 'w') as file_w:
+    with open(config.__file__, 'w', encoding='utf8') as file_w:
         for line in config_lines:
             if name in line.split("=")[0].strip():
                 file_w.write("{} = {}\n".format(name, state))

--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -185,6 +185,28 @@ def makeFilename(scene_information, query):
             else:
                 new_filename = new_filename.replace(field, "")
 
+    if FILENAME_REPLACEWORDS:
+        for old, new in FILENAME_REPLACEWORDS.items():
+            if type(new) is str:
+                new = [new]
+            if len(new) > 1:
+                if new[1] == "regex":
+                    tmp = re.sub(old, new[0], new_filename)
+                    if tmp != new_filename:
+                        log.LogDebug(f"Regex matched: {new_filename} -> {tmp}")
+                else:
+                    if new[1] == "word":
+                        tmp = re.sub(fr'([\s_-])({old})([\s_-])', f'\\1{new[0]}\\3', new_filename)
+                    elif new[1] == "any":
+                        tmp = new_filename.replace(old, new[0])
+                    if tmp != new_filename:
+                        log.LogDebug(f"'{old}' changed with '{new[0]}'")
+            else:
+                tmp = re.sub(fr'([\s_-])({old})([\s_-])', f'\\1{new[0]}\\3', new_filename)
+                if tmp != new_filename:
+                    log.LogDebug(f"'{old}' changed with '{new[0]}'")
+            new_filename = tmp    
+
     # cleanup
     new_filename = re.sub(r'[\s_-]+(?=\W{2})', ' ', new_filename)
     # remove multi space
@@ -305,6 +327,7 @@ FIELD_WHITESPACE_SEP = config.field_whitespaceSeperator
 FILENAME_LOWER = config.lowercase_Filename
 FILENAME_SPLITCHAR = config.filename_splitchar
 FILENAME_REMOVECHARACTER = config.removecharac_Filename
+FILENAME_REPLACEWORDS = config.replace_words
 
 PERFORMER_SPLITCHAR = config.performer_splitchar
 PERFORMER_LIMIT = config.performer_limit

--- a/plugins/renamerOnUpdate/renamerOnUpdate.yml
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.yml
@@ -1,7 +1,7 @@
 name: renamerOnUpdate
 description: Rename filename based on a template.
 url: https://github.com/stashapp/CommunityScripts
-version: 1.5
+version: 1.51
 exec:
   - python
   - "{pluginDir}/renamerOnUpdate.py"


### PR DESCRIPTION
Add a option to replace thing in your filename.

The second element of the list determine the system used. If you don't put this element, the default is word
`regex`: match a regex, `word`: match a word, `any`: match anything
difference between `word` & `any`: word is between seperator (`space  _  -`), any is anything ('ring' would replace 'during')

## Exemple:   
`"Scene": ["Sc.", "word"]`    - Replace Scene by Sc.
`r"S\d+:E\d+": ["", "regex"]` - Remove Sxx:Ex (x is a digit)
```py
replace_words = {
    r"S\d+:E\d+": ["", "regex"],
    "Be": ["lol", "word"],
    "Do": ["Is", "any"]
}
#Darcy Does It Best - S22:E6 -> Darcy Ises It Best
```

Also fix a bug when trying to disable/enable hook