### PR TITLE
[renamerOnUpdate] Major Update (Bulk, Mover...)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This list keeps track of scripts and plugins in this repository. Please ensure t
 Category|Triggers|Plugin Name|Description|Minimum Stash version
 --------|-----------|-----------|-----------|---------------------
 Scraper|Task|[GHScraper_Checker](plugins/GHScraper_Checker)|Compare local file against github file from the community scraper repo.|v0.8
-Maintenance|Scene.Update|[renamerOnUpdate](plugins/renamerOnUpdate)|Rename your file based on Stash metadata.|v0.7
+Maintenance|Task<br />Scene.Update|[renamerOnUpdate](plugins/renamerOnUpdate)|Rename/Move your file based on Stash metadata.|v0.7
 Maintenance|Set Scene Cover|[setSceneCoverFromFile](plugins/setSceneCoverFromFile)|Searchs Stash for Scenes with a cover image in the same folder and sets the cover image in stash to that image|v0.7
 Scenes|SceneMarker.Create<br />SceneMarker.Update|[markerTagToScene](plugins/markerTagToScene)|Adds primary tag of Scene Marker to the Scene on marker create/update.|v0.8 ([46bbede](https://github.com/stashapp/stash/commit/46bbede9a07144797d6f26cf414205b390ca88f9))
 Scanning|Scene.Create<br />Gallery.Create<br />Image.Create|[defaultDataForPath](plugins/defaultDataForPath)|Adds configured Tags, Performers and/or Studio to all newly scanned Scenes, Images and Galleries..|v0.8

--- a/plugins/renamerOnUpdate/README.md
+++ b/plugins/renamerOnUpdate/README.md
@@ -3,25 +3,34 @@ Using metadata from your Stash to rename/move your file.
 
 ## Table of Contents  
 
+- [*renamerOnUpdate*](#renameronupdate)
+	- [Table of Contents](#table-of-contents)
 - [Requirement](#requirement)
 - [Installation](#installation)
+		- [:exclamation: Make sure to configure the plugin by editing `config.py` before running it :exclamation:](#exclamation-make-sure-to-configure-the-plugin-by-editing-configpy-before-running-it-exclamation)
 - [Usage](#usage)
 - [Configuration](#configuration)
 - [Config.py explained](#configpy-explained)
-  * [Template](#template)
-  * [Filename (Renamer)](#filename)
-    + [- Based on a Tag](#--based-on-a-tag)
-    + [- Based on a Studio](#--based-on-a-studio)
-    + [- Change filename no matter what](#--change-filename-no-matter-what)
-  * [Path (Mover)](#path)
-    + [- Based on a Tag](#--based-on-a-tag-1)
-    + [- Based on a Studio](#--based-on-a-studio-1)
-    + [- Based on a Path](#--based-on-a-path)
-    + [- Change path no matter what](#--change-path-no-matter-what)
-    + [- Special Variables](#--special-variables)
-  * [Advanced](#advanced)
-    + [Groups](#groups)
-  * [Option](#option)
+	- [Template](#template)
+	- [- You can find the list of available variables in `config.py`](#--you-can-find-the-list-of-available-variables-in-configpy)
+	- [Filename](#filename)
+		- [- Based on a Tag](#--based-on-a-tag)
+		- [- Based on a Studio](#--based-on-a-studio)
+		- [- Change filename no matter what](#--change-filename-no-matter-what)
+	- [Path](#path)
+		- [- Based on a Tag](#--based-on-a-tag-1)
+		- [- Based on a Studio](#--based-on-a-studio-1)
+		- [- Based on a Path](#--based-on-a-path)
+		- [- Change path no matter what](#--change-path-no-matter-what)
+		- [- Special Variables](#--special-variables)
+	- [Advanced](#advanced)
+		- [Groups](#groups)
+	- [Option](#option)
+		- [*p_tag_option*](#p_tag_option)
+		- [*field_replacer*](#field_replacer)
+		- [*replace_words*](#replace_words)
+		- [*removecharac_Filename*](#removecharac_filename)
+		- [*performer_limit*](#performer_limit)
 
 # Requirement
 - Stash (v0.15+)
@@ -47,7 +56,7 @@ Using metadata from your Stash to rename/move your file.
 
 - By pressing the button in the Task menu.
     - It will go through each of your scenes. 
-    - `:warning:` It's recommend to understand correctly how this plugin work, and use **DryRun** first.
+    - `:warning:` It's recommended to understand correctly how this plugin works, and use **DryRun** first.
 
 # Configuration
 
@@ -55,28 +64,28 @@ Using metadata from your Stash to rename/move your file.
 	- Change template filename/path
 	- Add `log_file` path
 
-- There is multiple button in Task menu:
+- There are multiple buttons in Task menu:
 	- Enable: (default) Enable the trigger update
 	- Disable: Disable the trigger update
 	- Dry-run: A switch to enable/disable dry-run mode
 
 - Dry-run mode:
-	- It prevent editing the file, only show in your log.
+	- It prevents editing the file, only shows in your log.
 	- This mode can write into a file (`dryrun_renamerOnUpdate.txt`), the change that the plugin will do.
 		- You need to set a path for `log_file` in `config.py`
 		- The format will be: `scene_id|current path|new path`. (e.g. `100|C:\Temp\foo.mp4|C:\Temp\bar.mp4`)
-		- This file will be re-write everytime the plugin is trigger.
+		- This file will be overwritten everytime the plugin is triggered.
 
 # Config.py explained
 ## Template
-To modify your path/filename, you can use **variables**. There are elements that will change based on your **metadata**.
+To modify your path/filename, you can use **variables**. These are elements that will change based on your **metadata**.
 
- - Variable are represented with a word preceded with a `$` symbol. (E.g. `$date`)
- - If the metadata exist, this term will be replaced by it:
+ - Variables are represented with a word preceded with a `$` symbol. (E.g. `$date`)
+ - If the metadata exists, this term will be replaced by it:
 	 - Scene date = 2006-01-02, `$date` = 2006-01-02
  - You can find the list of available variables in `config.py`
 -----
-In the exemple below, we will use:
+In the example below, we will use:
 - Path: `C:\Temp\QmlnQnVja0J1bm55.mp4`
 - This file is [Big Buck Bunny](https://en.wikipedia.org/wiki/Big_Buck_Bunny).
 
@@ -173,22 +182,25 @@ The file is moved to: `D:\Video\QmlnQnVja0J1bm55.mp4`
 `^*` - The current directory of the file.
 Explanation:
  - **If**: `p_default_template = r"^*\$performer"`
- - It add a folder with a performer name in the current directory where the file is.
+ - It creates a folder with a performer name in the current directory where the file is.
  - `C:\Temp\video.mp4` so  `^*=C:\Temp\`, result: `C:\Temp\Jane Doe\video.mp4`
  - If you don't use `prevent_consecutive` option, the plugin will create a new folder everytime (`C:\Temp\Jane Doe\Jane Doe\...\video.mp4`).
 
 ## Advanced
 
 ### Groups
-You can specific group of element in the template with `{}`, it's used when you want to remove a character if a variable is null.
-Exemple:
+You can group elements in the template with `{}`, it's used when you want to remove a character if a variable is null.
+
+Example:
+
+
 **With** date in Stash:
  - `[$studio] $date - $title` -> `[Blender] 2008-05-20 - Big Buck Bunny`
  
 **Without** date in Stash:
  - `[$studio] $date - $title` -> `[Blender] - Big Buck Bunny`
  
-If you want to the `-` only when you have the date, you can group the `-` with `$date`
+If you want to use the `-` only when you have the date, you can group the `-` with `$date`
 **Without** date in Stash:
  - `[$studio] {$date -} $title` -> `[Blender] Big Buck Bunny`
 

--- a/plugins/renamerOnUpdate/README.md
+++ b/plugins/renamerOnUpdate/README.md
@@ -1,75 +1,206 @@
+# *renamerOnUpdate*
+Using metadata from your Stash to rename/move your file.
 
-# SQLITE Renamer for Stash
-Using metadata from your Stash to rename your file.
+## Table of Contents  
 
-## Requirement
-- Stash
-- Python 3+ (Tested on Python v3.9.1 64bit, Win10)
+- [Requirement](#requirement)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Configuration](#configuration)
+- [Config.py explained](#configpy-explained)
+  * [Template](#template)
+  * [Filename (Renamer)](#filename)
+    + [- Based on a Tag](#--based-on-a-tag)
+    + [- Based on a Studio](#--based-on-a-studio)
+    + [- Change filename no matter what](#--change-filename-no-matter-what)
+  * [Path (Mover)](#path)
+    + [- Based on a Tag](#--based-on-a-tag-1)
+    + [- Based on a Studio](#--based-on-a-studio-1)
+    + [- Based on a Path](#--based-on-a-path)
+    + [- Change path no matter what](#--change-path-no-matter-what)
+    + [- Special Variables](#--special-variables)
+  * [Advanced](#advanced)
+    + [Groups](#groups)
+  * [Option](#option)
+
+# Requirement
+- Stash (v0.15+)
+- Python 3.6+ (Tested on Python v3.9.1 64bit, Win10)
 - Request Module (https://pypi.org/project/requests/)
-- Tested on Windows 10 and Synology/docker (No idea if this work for all OS)
+- Tested on Windows 10/Synology/docker.
 
-## Installation
+# Installation
 
-- Download the whole folder 'renamerOnUpdate' (config.py, log.py, renamerOnUpdate.py/.yml)
+- Download the whole folder '**renamerOnUpdate**' (config.py, log.py, renamerOnUpdate.py/.yml)
 - Place it in your **plugins** folder (where the `config.yml` is)
-- Reload plugins (Settings > Plugins)
-- renamerOnUpdate appears 
+- Reload plugins (Settings > Plugins > Reload)
+- *renamerOnUpdate* appears
 
 ### :exclamation: Make sure to configure the plugin by editing `config.py` before running it :exclamation:
 
-## Usage
+# Usage
 
 - Everytime you update a scene, it will check/rename your file. An update can be:
 	- Saving in **Scene Edit**.
 	- Clicking the **Organized** button.
 	- Running a scan that **updates** the path.
 
-## Configuration
+- By pressing the button in the Task menu.
+    - It will go through each of your scenes. 
+    - `:warning:` It's recommend to understand correctly how this plugin work, and use **DryRun** first.
+
+# Configuration
 
 - Read/Edit `config.py`
-	- I recommend setting the **log_file** as it can be useful to revert.
+	- Change template filename/path
+	- Add `log_file` path
 
-### Example
+- There is multiple button in Task menu:
+	- Enable: (default) Enable the trigger update
+	- Disable: Disable the trigger update
+	- Dry-run: A switch to enable/disable dry-run mode
 
-> Note: The priority is Tag > Studio > Default
+- Dry-run mode:
+	- It prevent editing the file, only show in your log.
+	- This mode can write into a file (`dryrun_renamerOnUpdate.txt`), the change that the plugin will do.
+		- You need to set a path for `log_file` in `config.py`
+		- The format will be: `scene_id|current path|new path`. (e.g. `100|C:\Temp\foo.mp4|C:\Temp\bar.mp4`)
+		- This file will be re-write everytime the plugin is trigger.
 
-The config will be:
+# Config.py explained
+## Template
+To modify your path/filename, you can use **variables**. There are elements that will change based on your **metadata**.
+
+ - Variable are represented with a word preceded with a `$` symbol. (E.g. `$date`)
+ - If the metadata exist, this term will be replaced by it:
+	 - Scene date = 2006-01-02, `$date` = 2006-01-02
+ - You can find the list of available variables in `config.py`
+-----
+In the exemple below, we will use:
+- Path: `C:\Temp\QmlnQnVja0J1bm55.mp4`
+- This file is [Big Buck Bunny](https://en.wikipedia.org/wiki/Big_Buck_Bunny).
+
+## Filename
+Change your filename (C:\Temp\\**QmlnQnVja0J1bm55.mp4**)
+
+------
+**Priority** : Tags > Studios > Default
+### - Based on a Tag
 ```py
-
-# Change filename if the tag 'rename_tag' is present.
 tag_templates  = {
 	"rename_tag": "$year $title - $studio $resolution $video_codec",
+	"rename_tag2": "$title"
 }
-
-# Change filename for scenes from 'Vixen' or 'Slayed' studio.
-studio_templates  = {
-	"Slayed": "$date $performer - $title [$studio]",
-	"Vixen": "$performer - $title [$studio]"
-}
-
-# Change filename no matter what
-use_default_template  =  True
-
-default_template  =  "$date $title"
-
-# Use space as a performer separator
-performer_splitchar  =  " "
-
-# If the scene has more than 3 performers, the $performer field will be ignored.
-performer_limit  =  3
 ```
+|tag| new path |
+|--|--|
+|rename_tag| `C:\Temp\2008 Big Buck Bunny - Blender Institute 1080p H264.mp4` |
+| rename_tag2 | `C:\Temp\Big Buck Bunny.mp4` |
 
-The scene was just scanned, everything is default (Title = Filename).
 
-Current filename: `Slayed.21.09.02.Ariana.Marie.Emily.Willis.And.Eliza.Ibarra.XXX.1080p.mp4`
 
-|Stash Field  | Value | Filename | Trigger template |
-|--|:---:|--|--|
-| - | *Default* |`Slayed.21.09.02.Ariana.Marie.Emily.Willis.And.Eliza.Ibarra.XXX.1080p.mp4` | default_template
-| ~Title| **Driver**| `Driver.mp4` | default_template
-| +Date| **2021-09-02**| `2021-09-02 Driver.mp4` | default_template
-| +Performer | **Ariana Marie<br>Emily Willis<br>Eliza Ibarra**| `2021-09-02 Driver.mp4` | default_template
-| +Studio | **Vixen**| `Ariana Marie Emily Willis Eliza Ibarra - Driver [Vixen].mp4` | studio_templates [Vixen]
-| ~Studio | **Slayed**| `2021-09-02 Ariana Marie Emily Willis Eliza Ibarra - Driver [Slayed].mp4` | studio_templates [Slayed]
-| +Performer | **Elsa Jean**| `2021-09-02 Driver [Slayed].mp4` | studio_templates [Slayed]<br>**Reach performer_limit**.
-| +Tag | **rename_tag**| `2021 Driver - Slayed HD h264.mp4` | tag_templates [rename_tag]
+### - Based on a Studio
+```py
+studio_templates  = {
+	"Blender Institute": "$date - $title [$studio]",
+	"Pixar": "$title [$studio]"
+}
+```
+|studio| new path |
+|--|--|
+|Blender Institute| `C:\Temp\2008-05-20 - Big Buck Bunny [Blender Institute].mp4` |
+| Pixar | `C:\Temp\Big Buck Bunny [Pixar].mp4` |
+
+
+### - Change filename no matter what
+```py
+use_default_template  =  True
+default_template  =  "$date $title"
+```
+The file became: `C:\Temp\2008-05-20 - Big Buck Bunny.mp4`
+
+## Path
+Change your path (**C:\Temp**\\QmlnQnVja0J1bm55.mp4)
+### - Based on a Tag
+```py
+p_tag_templates  = {
+	"rename_tag": r"D:\Video\",
+	"rename_tag2": r"E:\Video\$year"
+}
+```
+|tag| new path |
+|--|--|
+|rename_tag| `D:\Video\QmlnQnVja0J1bm55.mp4` |
+| rename_tag2 | `E:\Video\2008\QmlnQnVja0J1bm55.mp4` |
+
+
+
+### - Based on a Studio
+```py
+p_studio_templates  = {
+	"Blender Institute": r"D:\Video\Blender\",
+	"Pixar": r"E:\Video\$studio\"
+}
+```
+|studio| new path |
+|--|--|
+|Blender Institute| `D:\Video\Blender\QmlnQnVja0J1bm55.mp4` |
+| Pixar | `E:\Video\Pixar\QmlnQnVja0J1bm55.mp4` |
+
+### - Based on a Path
+```py
+p_path_templates = {
+	r"C:\Temp": r"D:\Video\",
+	r"C:\Video": r"E:\Video\Win\"
+}
+```
+|file path| new path |
+|--|--|
+|`C:\Temp`| `D:\Video\QmlnQnVja0J1bm55.mp4` |
+| `C:\Video`| `E:\Video\Win\QmlnQnVja0J1bm55.mp4` |
+
+
+### - Change path no matter what
+```py
+p_use_default_template  =  True
+p_default_template  =  r"D:\Video\"
+```
+The file is moved to: `D:\Video\QmlnQnVja0J1bm55.mp4`
+
+### - Special Variables
+`$studio_hierarchy` - Create the entire hierarchy of studio as folder (E.g. `../MindGeek/Brazzers/Hot And Mean/video.mp4`). Use your parent studio.
+
+`^*` - The current directory of the file.
+Explanation:
+ - **If**: `p_default_template = r"^*\$performer"`
+ - It add a folder with a performer name in the current directory where the file is.
+ - `C:\Temp\video.mp4` so  `^*=C:\Temp\`, result: `C:\Temp\Jane Doe\video.mp4`
+ - If you don't use `prevent_consecutive` option, the plugin will create a new folder everytime (`C:\Temp\Jane Doe\Jane Doe\...\video.mp4`).
+
+## Advanced
+
+### Groups
+You can specific group of element in the template with `{}`, it's used when you want to remove a character if a variable is null.
+Exemple:
+**With** date in Stash:
+ - `[$studio] $date - $title` -> `[Blender] 2008-05-20 - Big Buck Bunny`
+ 
+**Without** date in Stash:
+ - `[$studio] $date - $title` -> `[Blender] - Big Buck Bunny`
+ 
+If you want to the `-` only when you have the date, you can group the `-` with `$date`
+**Without** date in Stash:
+ - `[$studio] {$date -} $title` -> `[Blender] Big Buck Bunny`
+
+## Option
+
+### *p_tag_option*
+...
+### *field_replacer*
+...
+### *replace_words*
+...
+### *removecharac_Filename*
+...
+### *performer_limit*
+...

--- a/plugins/renamerOnUpdate/config.py
+++ b/plugins/renamerOnUpdate/config.py
@@ -38,9 +38,6 @@
 # $parent_studio $date $performer - $title  == Reality Kings 2016-12-29 Eva Lovia - Her Fantasy Ball
 # $date $title - $tags                      == 2016-12-29 Her Fantasy Ball - Blowjob Cumshot Facial Tattoo
 #
-####################################################################
-#                STASH               #
-stash_url = "localhost"
 
 ####################################################################
 #           TEMPLATE FILENAME (Rename your files)

--- a/plugins/renamerOnUpdate/config.py
+++ b/plugins/renamerOnUpdate/config.py
@@ -48,6 +48,7 @@ stash_url = "localhost"
 
 # Templates to use for given tags
 # Add or remove as needed or leave it empty/comment out
+# you can specific group with {}. exemple: [$studio] {$date -} $title, the '-' will be removed if no date
 tag_templates = {
     # "!1. Western": "$date $performer - $title [$studio]",
     # "!1. JAV": "$title",
@@ -90,6 +91,9 @@ p_path_templates = {
 p_use_default_template = False
 # default template, adjust as needed
 p_default_template = r"^*\$performer"
+
+# if unorganized, ignore other templates, use this path
+p_non_organized = r""
 
 # option if tag is present
 # "tagname": [option]

--- a/plugins/renamerOnUpdate/config.py
+++ b/plugins/renamerOnUpdate/config.py
@@ -15,11 +15,16 @@
 #   $tags
 #   $video_codec 
 #   $audio_codec
+#   $movie_scene
+#   $movie_title
+#   $movie_year
+#   $movie_scene
 #
 # Note:
 # $studio_family: If parent studio exists use it, else use the studio name.
 # $performer: If more than * performers linked to the scene, this field will be ignored. Limit this number at Settings section below (default: 3)
 # $resolution: SD/HD/UHD/VERTICAL (for phone) | $height: 720p 1080p 4k 8k
+# $movie_scene: "scene #" # = index scene
 # -----------------------------------------------------------------
 # Example templates:
 # 
@@ -36,7 +41,8 @@
 #                STASH               #
 stash_url = "localhost"
 
-#               TEMPLATE             #
+####################################################################
+#           TEMPLATE FILENAME (Rename your files)
 
 # Priority : Tags > Studios > Default
 
@@ -58,6 +64,41 @@ use_default_template = False
 # Default template, adjust as needed
 default_template = "$date $title"
 
+####################################################################
+#           TEMPLATE PATH  (Move your files)
+
+# $studio_hierarchy: create the whole hierarchy folder (MindGeek/Brazzers/Hot And Mean/video.mp4)
+# ^* = parent of folder (E:\Movies\video.mp4 -> E:\Movies\)
+
+# trigger with a specific tag
+# "tagname": "path"
+# ex: "plugin_move": r"E:\Movies\R18\$studio_hierarchy"
+p_tag_templates = {
+    "plugin_move_atrier": r"E:\Film\R18\2. Test\$studio_hierarchy"
+}
+
+
+p_studio_templates = {
+}
+
+# match a path
+# "match path": "destination"
+# ex: r"E:\Film\R18\2. Test\A trier": r"E:\Film\R18\2. Test\A trier\$performer",
+p_path_templates = {
+}
+
+# change to True to use the default template if no specific tag/studio is found
+p_use_default_template = False
+# default template, adjust as needed
+p_default_template = r"^*\$performer"
+
+# option if tag is present
+# "tagname": [option]
+# clean_tag: remove the tag after the rename
+# inverse_performer: change the last/first name (Jane Doe -> Doe Jane)
+# ex: "plugin_move": ["clean_tag"]
+p_tag_option = {
+}
 ######################################
 #               Logging              #
 
@@ -91,6 +132,10 @@ removecharac_Filename = ",#"
 performer_splitchar = " "
 # Maximum number of performer names in the filename. If there are more than that in a scene the filename will not include any performer name!
 performer_limit = 3
+# The filename with have the name of performer before reaching the limit (if limit=3, the filename can contains 3 performers for a 4 performers scenes)
+performer_limit_keep = False
+# sorting performer (name, id, rating, favorite, mix (favorite > rating > name), mixid (..>..> id))
+performer_sort = "id"
 # ignore certain gender. Available "MALE" "FEMALE" "TRANSGENDER_MALE" "TRANSGENDER_FEMALE" "INTERSEX" "NON_BINARY"
 performer_ignoreGender = []
 
@@ -99,6 +144,16 @@ performer_ignoreGender = []
 # Template used: $year $performer - $title
 # 2016 Dani Daniels - Dani Daniels in ***.mp4 --> 2016 Dani Daniels in ***.mp4
 prevent_title_performer = False
+
+## Path mover related
+# remove consecutive (/FolderName/FolderName/video.mp4 -> FolderName/video.mp4
+prevent_consecutive = True
+# check when the file has moved that the old directory is empty, if empty it will remove it.
+remove_emptyfolder = True
+# if there is no performer on the scene, the $performer field will be replaced by "NoPerformer" so a folder "NoPerformer" will be created
+path_noperformer_folder = False
+# if the folder already have a performer name, it won't change it
+path_keep_alrperf = True
 
 # Removes prepositions from the beginning of titles
 prepositions_list = ['The', 'A', 'An']
@@ -146,8 +201,13 @@ order_field = ["$video_codec", "$audio_codec", "$resolution", "tags", "rating", 
 # Alternate way to show diff. Not useful at all.
 alt_diff_display = False
 
+# number of scene process by the task renamer. -1 = all scenes
+batch_number_scene = -1
+
 # disable/enable the hook. You can edit this value in 'Plugin Tasks' inside of Stash.
 enable_hook = True
+# disable/enable dry mode. This prevent any change, it will only show in log. You can edit this value in 'Plugin Tasks' inside of Stash.
+dry_run = False
 ######################################
 #            Module Related          #
 

--- a/plugins/renamerOnUpdate/config.py
+++ b/plugins/renamerOnUpdate/config.py
@@ -8,7 +8,7 @@
 #   $title 
 #   $height 
 #   $resolution 
-#   $bitrate
+#   $bitrate (megabits per second)
 #   $studio 
 #   $parent_studio 
 #   $studio_family 

--- a/plugins/renamerOnUpdate/config.py
+++ b/plugins/renamerOnUpdate/config.py
@@ -95,6 +95,7 @@ p_default_template = r"^*\$performer"
 # "tagname": [option]
 # clean_tag: remove the tag after the rename
 # inverse_performer: change the last/first name (Jane Doe -> Doe Jane)
+# dry_run: activate dry_run for this scene
 # ex: "plugin_move": ["clean_tag"]
 p_tag_option = {
 }

--- a/plugins/renamerOnUpdate/config.py
+++ b/plugins/renamerOnUpdate/config.py
@@ -126,6 +126,11 @@ filename_splitchar = " "
 
 # replace space for stash field (title, performer...), if you have a title 'I love Stash' it can become 'I_love_Stash'
 field_whitespaceSeperator = ""
+# Remove/Replace character from field (not using regex)
+# "field": {"replace": "foo","with": "bar"}
+# ex: "$studio": {"replace": "'","with": ""} My Dad's Hot Girlfriend --> My Dads Hot Girlfriend
+field_replacer = {
+}
 
 # Match and replace.
 # "match": ["replace with", "system"] the second element of the list determine the system used. If you don't put this element, the default is word
@@ -138,6 +143,8 @@ replace_words = {
 
 # put the filename in lowercase
 lowercase_Filename = False
+# filename in title case (Capitalises each word and lowercases the rest)
+titlecase_Filename = False
 # remove these characters if there are present in the filename
 removecharac_Filename = ",#"
 

--- a/plugins/renamerOnUpdate/config.py
+++ b/plugins/renamerOnUpdate/config.py
@@ -170,6 +170,8 @@ prevent_title_performer = False
 prevent_consecutive = True
 # check when the file has moved that the old directory is empty, if empty it will remove it.
 remove_emptyfolder = True
+# the folder will only contains 1 performer name
+path_one_performer = True
 # if there is no performer on the scene, the $performer field will be replaced by "NoPerformer" so a folder "NoPerformer" will be created
 path_noperformer_folder = False
 # if the folder already have a performer name, it won't change it

--- a/plugins/renamerOnUpdate/config.py
+++ b/plugins/renamerOnUpdate/config.py
@@ -8,6 +8,7 @@
 #   $title 
 #   $height 
 #   $resolution 
+#   $bitrate
 #   $studio 
 #   $parent_studio 
 #   $studio_family 

--- a/plugins/renamerOnUpdate/config.py
+++ b/plugins/renamerOnUpdate/config.py
@@ -219,7 +219,8 @@ batch_number_scene = -1
 
 # disable/enable the hook. You can edit this value in 'Plugin Tasks' inside of Stash.
 enable_hook = True
-# disable/enable dry mode. This prevent any change, it will only show in log. You can edit this value in 'Plugin Tasks' inside of Stash.
+# disable/enable dry mode. Do a trial run with no permanent changes. Can write into a file (dryrun_renamerOnUpdate.txt), set a path for log_file. 
+# You can edit this value in 'Plugin Tasks' inside of Stash.
 dry_run = False
 ######################################
 #            Module Related          #

--- a/plugins/renamerOnUpdate/config.py
+++ b/plugins/renamerOnUpdate/config.py
@@ -74,7 +74,6 @@ default_template = "$date $title"
 # "tagname": "path"
 # ex: "plugin_move": r"E:\Movies\R18\$studio_hierarchy"
 p_tag_templates = {
-    "plugin_move_atrier": r"E:\Film\R18\2. Test\$studio_hierarchy"
 }
 
 

--- a/plugins/renamerOnUpdate/config.py
+++ b/plugins/renamerOnUpdate/config.py
@@ -170,7 +170,7 @@ prevent_title_performer = False
 prevent_consecutive = True
 # check when the file has moved that the old directory is empty, if empty it will remove it.
 remove_emptyfolder = True
-# the folder will only contains 1 performer name
+# the folder only contains 1 performer name. Else it will look the same as for filename
 path_one_performer = True
 # if there is no performer on the scene, the $performer field will be replaced by "NoPerformer" so a folder "NoPerformer" will be created
 path_noperformer_folder = False

--- a/plugins/renamerOnUpdate/config.py
+++ b/plugins/renamerOnUpdate/config.py
@@ -2,6 +2,8 @@
 #       General information         #
 # -----------------------------------------------------------------
 # Available elements for renaming:
+#   $oshash 
+#   $checksum 
 #   $date 
 #   $year 
 #   $performer 
@@ -24,7 +26,7 @@
 # Note:
 # $studio_family: If parent studio exists use it, else use the studio name.
 # $performer: If more than * performers linked to the scene, this field will be ignored. Limit this number at Settings section below (default: 3)
-# $resolution: SD/HD/UHD/VERTICAL (for phone) | $height: 720p 1080p 4k 8k
+# $resolution: SD/HD/UHD/VERTICAL (for phone) | $height: 720p 1080p 4k 5k 6k 8k
 # $movie_scene: "scene #" # = index scene
 # -----------------------------------------------------------------
 # Example templates:

--- a/plugins/renamerOnUpdate/config.py
+++ b/plugins/renamerOnUpdate/config.py
@@ -122,6 +122,15 @@ filename_splitchar = " "
 # replace space for stash field (title, performer...), if you have a title 'I love Stash' it can become 'I_love_Stash'
 field_whitespaceSeperator = ""
 
+# Match and replace.
+# "match": ["replace with", "system"] the second element of the list determine the system used. If you don't put this element, the default is word
+# regex: match a regex, word: match a word, any: match a term
+# difference between 'word' & 'any': word is between seperator (space, _, -), any is anything ('ring' would replace 'during')
+# ex:   "Scene": ["Sc.", "word"]    - Replace Scene by Sc.
+#       r"S\d+:E\d+": ["", "regex"] - Remove Sxx:Ex (x is a digit)
+replace_words = {
+}
+
 # put the filename in lowercase
 lowercase_Filename = False
 # remove these characters if there are present in the filename

--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -867,7 +867,7 @@ def renamer(scene_id, db_conn=None):
         template["filename"] = config.default_template
 
     if not template["filename"] and not template["path"]:
-        log.LogWarning("[{scene_id}] No template for this scene.")
+        log.LogWarning(f"[{scene_id}] No template for this scene.")
         return
 
     #log.LogDebug("Using this template: {}".format(filename_template))

--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -487,6 +487,8 @@ def extract_info(scene: dict, template: None):
                 log.LogInfo(f"Limited the amount of performer to {PERFORMER_LIMIT}")
                 perf_list = perf_list[0: PERFORMER_LIMIT]
         scene_information['performer'] = PERFORMER_SPLITCHAR.join(perf_list)
+        if not PATH_ONEPERFORMER:
+            scene_information['performer_path'] = PERFORMER_SPLITCHAR.join(perf_list)
     elif PATH_NOPERFORMER_FOLDER:
         scene_information['performer_path'] = "NoPerformer"
 
@@ -1068,6 +1070,7 @@ ALT_DIFF_DISPLAY = config.alt_diff_display
 PATH_NOPERFORMER_FOLDER = config.path_noperformer_folder
 PATH_KEEP_ALRPERF = config.path_keep_alrperf
 PATH_NON_ORGANIZED = config.p_non_organized
+PATH_ONEPERFORMER = config.path_one_performer
 
 if PLUGIN_ARGS:
     if "bulk" in PLUGIN_ARGS:

--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -539,6 +539,10 @@ def extract_info(scene: dict, template: None):
     if scene['file']['height'] >= 2160:
         scene_information['height'] = '4k'
         scene_information['resolution'] = 'UHD'
+    if scene['file']['height'] >= 2880:
+        scene_information['height'] = '5k'
+    if scene['file']['height'] >= 3384:
+        scene_information['height'] = '6k'
     if scene['file']['height'] >= 4320:
         scene_information['height'] = '8k'
     # For Phone ?

--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -292,16 +292,19 @@ def has_handle(fpath, all_result=False):
 
 def config_edit(name: str, state: bool):
     found = 0
-    with open(config.__file__, 'r', encoding='utf8') as file:
-        config_lines = file.readlines()
-    with open(config.__file__, 'w', encoding='utf8') as file_w:
-        for line in config_lines:
-            if len(line.split("=")) > 1:
-                if name in line.split("=")[0].strip():
-                    file_w.write(f"{name} = {state}\n")
-                    found += 1
-                    continue
-            file_w.write(line)
+    try:
+        with open(config.__file__, 'r', encoding='utf8') as file:
+            config_lines = file.readlines()
+        with open(config.__file__, 'w', encoding='utf8') as file_w:
+            for line in config_lines:
+                if len(line.split("=")) > 1:
+                    if name in line.split("=")[0].strip():
+                        file_w.write(f"{name} = {state}\n")
+                        found += 1
+                        continue
+                file_w.write(line)
+    except PermissionError as err:
+        log.LogError(f"You don't have the permission to edit config.py ({err})")
     return found
 
 

--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -781,7 +781,11 @@ def file_rename(scene_info: dict, template: dict):
                     p.terminate()
                     p.wait(10)
                     # If process is not terminated, this will create an error again.
-                    os.rename(scene_info['current_path'], scene_info['final_path'])
+                    try:
+                        shutil.move(scene_info['current_path'], scene_info['final_path'])
+                    except Exception as err:
+                        log.LogError(f"Something still prevents renaming the file. {err}")
+                        return 1
                 else:
                     log.LogError("A process prevents renaming the file.")
                     return 1
@@ -796,7 +800,7 @@ def file_rename(scene_info: dict, template: dict):
                 with open(LOGFILE, 'a', encoding='utf-8') as f:
                     f.write(f"{scene_info['scene_id']}|{scene_info['current_path']}|{scene_info['final_path']}|{scene_info['hash']}\n")
             except Exception as err:
-                os.rename(scene_info['final_path'], scene_info['current_path'])
+                shutil.move(scene_info['final_path'], scene_info['current_path'])
                 log.LogError(f"Restoring the original path, error writing the logfile: {err}")
                 return 1
         if REMOVE_EMPTY_FOLDER:
@@ -823,7 +827,7 @@ def associated_rename(scene_info: dict):
             p_new = os.path.splitext(scene_info['final_path'])[0] + "." + ext
             if os.path.isfile(p):
                 try:
-                    os.rename(p, p_new)
+                    shutil.move(p, p_new)
                 except Exception as err:
                     log.LogError(f"Something prevents renaming this file '{p}' - err: {err}")
                     continue
@@ -834,7 +838,7 @@ def associated_rename(scene_info: dict):
                         with open(LOGFILE, 'a', encoding='utf-8') as f:
                             f.write(f"{scene_info['scene_id']}|{p}|{p_new}\n")
                     except Exception as err:
-                        os.rename(p_new, p)
+                        shutil.move(p_new, p)
                         log.LogError(f"Restoring the original name, error writing the logfile: {err}")
 
 

--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -374,7 +374,7 @@ def get_template_path(scene: dict):
             if config.p_tag_option.get(tag["name"]):
                 opt = config.p_tag_option[tag["name"]]
                 template["option"].extend(opt)
-                if opt == "clean_tag":
+                if "clean_tag" in opt:
                     if template["opt_details"].get("clean_tag"):
                         template["opt_details"]["clean_tag"].append(tag["id"])
                     else:

--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -896,10 +896,10 @@ def renamer(scene_id, db_conn=None):
     else:
         scene_information['new_filename'] = scene_information['current_filename']
     if template.get("path"):
-        scene_information['new_path'] = create_new_path(scene_information, template)
+        scene_information['new_directory'] = create_new_path(scene_information, template)
     else:
-        scene_information['new_path'] = scene_information['current_path']
-    scene_information['final_path'] = os.path.join(scene_information['new_path'], scene_information['new_filename'])
+        scene_information['new_directory'] = scene_information['current_directory']
+    scene_information['final_path'] = os.path.join(scene_information['new_directory'], scene_information['new_filename'])
     # check length of path
     if check_longpath(scene_information['final_path']):
         if (DRY_RUN or option_dryrun) and LOGFILE:
@@ -908,13 +908,13 @@ def renamer(scene_id, db_conn=None):
         return
 
     #log.LogDebug(f"Filename: {scene_information['current_filename']} -> {scene_information['new_filename']}")
-    #log.LogDebug(f"Path: {scene_information['current_path']} -> {scene_information['new_path']}")
+    #log.LogDebug(f"Path: {scene_information['current_directory']} -> {scene_information['new_directory']}")
 
     if scene_information['final_path'] == scene_information['current_path']:
         log.LogInfo(f"Everything is ok. ({scene_information['current_filename']})")
         return
 
-    if scene_information['current_directory'] != scene_information['new_path']:
+    if scene_information['current_directory'] != scene_information['new_directory']:
         log.LogInfo("File will be moved to another directory")
         log.LogDebug(f"[OLD path] {scene_information['current_path']}")
         log.LogDebug(f"[NEW path] {scene_information['final_path']}")

--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -700,7 +700,9 @@ def create_new_path(scene_info: dict, template: dict):
     for part in path_split:
         if ":" in part and path_split[0]:
             path_list.append(part)
-        elif part == "$studio_hierarchy" and scene_info.get("studio_hierarchy"):
+        elif part == "$studio_hierarchy":
+            if not scene_info.get("studio_hierarchy"):
+                continue
             for p in scene_info["studio_hierarchy"]:
                 path_list.append(re.sub('[\\/:"*?<>|]+', '', p).strip())
         else:

--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -808,8 +808,9 @@ def file_rename(scene_info: dict, template: dict):
         # I don't think it's possible.
         log.LogError(f"[OS] Failed to rename the file ? {scene_info['final_path']}")
         return 1
-    if "clean_tag" in template["option"]:
-        graphql_removeScenesTag([scene_info['scene_id']], template["opt_details"]["clean_tag"])
+    if template.get("path"):
+        if "clean_tag" in template["path"]["option"]:
+            graphql_removeScenesTag([scene_info['scene_id']], template["path"]["opt_details"]["clean_tag"])
 
 
 def associated_rename(scene_info: dict):

--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -489,6 +489,7 @@ def extract_info(scene: dict, template: None):
         else:
             scene_information['studio'] = scene['studio']['name']
         scene_information['studio_family'] = scene_information['studio']
+        studio_hierarchy = [scene_information['studio']]
         # Grab Parent name
         if scene['studio'].get("parent_studio"):
             if SQUEEZE_STUDIO_NAMES:
@@ -498,13 +499,12 @@ def extract_info(scene: dict, template: None):
             scene_information['studio_family'] = scene_information['parent_studio']
 
             studio_p = scene['studio']
-            studio_hierarchy = [scene_information['studio']]
             while studio_p.get("parent_studio"):
                 studio_p = graphql_getStudio(studio_p['parent_studio']['id'])
                 if studio_p:
                     studio_hierarchy.append(studio_p['name'])
             studio_hierarchy.reverse()
-            scene_information['studio_hierarchy'] = studio_hierarchy
+        scene_information['studio_hierarchy'] = studio_hierarchy
     # Grab Tags
     if scene.get("tags"):
         tag_list = []

--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -803,7 +803,10 @@ def file_rename(scene_info: dict, template: dict):
             with os.scandir(scene_info['current_directory']) as it:
                 if not any(it):
                     log.LogInfo(f"Removing empty folder ({scene_info['current_directory']})")
-                    os.remove(scene_info['current_directory'])
+                    try:
+                        os.rmdir(scene_info['current_directory'])
+                    except Exception as err:
+                        log.logWarning(f"Fail to delete empty folder {scene_info['current_directory']} - {err}")
     else:
         # I don't think it's possible.
         log.LogError(f"[OS] Failed to rename the file ? {scene_info['final_path']}")

--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -669,6 +669,9 @@ def create_new_path(scene_info: dict, template: dict):
         path_split = scene_info['template_split']
         path_list = []
         for part in path_split:
+            if ":" in part and path_split[0]:
+                path_list.append(part)
+                continue
             if part == "$studio_hierarchy" and scene_info.get("studio_hierarchy"):
                 for p in scene_info["studio_hierarchy"]:
                     path_list.append(re.sub('[\\/:"*?<>|]+', '', p).strip())

--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -476,7 +476,6 @@ def extract_info(scene: dict, template: None):
         scene_information['performer'] = PERFORMER_SPLITCHAR.join(perf_list)
     elif PATH_NOPERFORMER_FOLDER:
         scene_information['performer_path'] = "NoPerformer"
-        scene_information["performer"] = "NoPerformer"
 
     # Grab Studio name
     if scene.get("studio"):

--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -671,9 +671,9 @@ def create_new_path(scene_info: dict, template: dict):
         for part in path_split:
             if part == "$studio_hierarchy" and scene_info.get("studio_hierarchy"):
                 for p in scene_info["studio_hierarchy"]:
-                    path_list.append(re.sub('["*?<>|#,]+', '', p).strip())
+                    path_list.append(re.sub('[\\/:"*?<>|]+', '', p).strip())
             else:
-                path_list.append(re.sub('["*?<>|#,]+', '', makePath(scene_info, part)).strip())
+                path_list.append(re.sub('[\\/:"*?<>|]+', '', makePath(scene_info, part)).strip())
         # Remove blank, empty string
         path_split = [x for x in path_list if x]
         # The first character was a seperator, so put it back.
@@ -843,7 +843,7 @@ def renamer(scene_id, db_conn=None):
     if not template["path"].get("destination"):
         if config.p_use_default_template:
             log.LogDebug("[PATH] Using default template")
-            template["path"] = {"destination": config.default_template, "option": [], "opt_details": {}}
+            template["path"] = {"destination": config.p_default_template, "option": [], "opt_details": {}}
         else:
             template["path"] = None
     if not template["filename"] and config.use_default_template:

--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -970,6 +970,7 @@ def renamer(scene_id, db_conn=None):
     except Exception as err:
         log.LogError(f"Error during database operation ({err})")
         if not db_conn:
+            log.LogDebug("[SQLITE] Database closed")
             stash_db.close()
         return
     if not db_conn:

--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -531,6 +531,7 @@ def extract_info(scene: dict, template: None):
         scene_information['tags'] = TAGS_SPLITCHAR.join(tag_list)
 
     # Grab Height (720p,1080p,4k...)
+    scene_information['bitrate'] = round(int(scene['file']['bitrate']) / 1000000, 2)
     scene_information['resolution'] = 'SD'
     scene_information['height'] = f"{scene['file']['height']}p"
     if scene['file']['height'] >= 720:
@@ -1023,7 +1024,7 @@ LOGFILE = config.log_file
 
 STASH_CONFIG = graphql_getConfiguration()
 STASH_DATABASE = STASH_CONFIG['general']['databasePath']
-TEMPLATE_FIELD = "$date $year $performer_path $performer $title $height $resolution $parent_studio $studio_family $studio $rating $tags $video_codec $audio_codec $movie_title $movie_year $movie_scene".split(" ")
+TEMPLATE_FIELD = "$date $year $performer_path $performer $title $height $resolution $bitrate $parent_studio $studio_family $studio $rating $tags $video_codec $audio_codec $movie_title $movie_year $movie_scene".split(" ")
 
 # READING CONFIG
 

--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -4,7 +4,6 @@ import os
 import re
 import shutil
 import sqlite3
-import subprocess
 import sys
 import time
 

--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -291,11 +291,12 @@ def config_edit(name: str, state: bool):
         config_lines = file.readlines()
     with open(config.__file__, 'w', encoding='utf8') as file_w:
         for line in config_lines:
-            if name in line.split("=")[0].strip():
-                file_w.write(f"{name} = {state}\n")
-                found += 1
-            else:
-                file_w.write(line)
+            if len(line.split("=")) > 1:
+                if name in line.split("=")[0].strip():
+                    file_w.write(f"{name} = {state}\n")
+                    found += 1
+                    continue
+            file_w.write(line)
     return found
 
 

--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -873,7 +873,10 @@ def renamer(scene_id, db_conn=None):
     log.LogDebug(f"[{scene_id}] Template: {template}")
 
     scene_information['scene_id'] = scene_id
-    scene_information['new_filename'] = create_new_filename(scene_information, template["filename"])
+    if template["filename"]:
+        scene_information['new_filename'] = create_new_filename(scene_information, template["filename"])
+    else:
+        scene_information['new_filename'] = scene_information['current_filename']
     scene_information['new_path'] = create_new_path(scene_information, template)
     if scene_information['new_path'] is None:
         return

--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -97,6 +97,7 @@ def graphql_getScene(scene_id):
     fragment SceneData on Scene {
         id
         oshash
+        checksum
         title
         date
         rating
@@ -158,6 +159,7 @@ def graphql_findScene(perPage, direc="DESC") -> dict:
     fragment SlimSceneData on Scene {
         id
         oshash
+        checksum
         title
         date
         rating
@@ -404,7 +406,8 @@ def extract_info(scene: dict, template: None):
     # note: basename contains the extension
     scene_information['current_filename'] = os.path.basename(scene_information['current_path'])
     scene_information['current_directory'] = os.path.dirname(scene_information['current_path'])
-    scene_information['hash'] = scene['oshash']
+    scene_information['oshash'] = scene['oshash']
+    scene_information['checksum'] = scene.get("checksum")
 
     if template.get("path"):
         if "^*" in template["path"]["destination"]:
@@ -829,7 +832,7 @@ def file_rename(scene_info: dict, template: dict):
         if LOGFILE:
             try:
                 with open(LOGFILE, 'a', encoding='utf-8') as f:
-                    f.write(f"{scene_info['scene_id']}|{scene_info['current_path']}|{scene_info['final_path']}|{scene_info['hash']}\n")
+                    f.write(f"{scene_info['scene_id']}|{scene_info['current_path']}|{scene_info['final_path']}|{scene_info['oshash']}\n")
             except Exception as err:
                 shutil.move(scene_info['final_path'], scene_info['current_path'])
                 log.LogError(f"Restoring the original path, error writing the logfile: {err}")
@@ -1038,7 +1041,7 @@ LOGFILE = config.log_file
 
 STASH_CONFIG = graphql_getConfiguration()
 STASH_DATABASE = STASH_CONFIG['general']['databasePath']
-TEMPLATE_FIELD = "$date $year $performer_path $performer $title $height $resolution $bitrate $parent_studio $studio_family $studio $rating $tags $video_codec $audio_codec $movie_title $movie_year $movie_scene".split(" ")
+TEMPLATE_FIELD = "$date $year $performer_path $performer $title $height $resolution $bitrate $parent_studio $studio_family $studio $rating $tags $video_codec $audio_codec $movie_title $movie_year $movie_scene $oshash $checksum".split(" ")
 
 # READING CONFIG
 

--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -2,8 +2,11 @@ import difflib
 import json
 import os
 import re
+import shutil
 import sqlite3
+import subprocess
 import sys
+import time
 
 import requests
 
@@ -19,32 +22,33 @@ try:
 except Exception:
     MODULE_UNIDECODE = False
 
-import config
 
+import config
 import log
 
-DRY_RUN = False
+DRY_RUN = config.dry_run
+if DRY_RUN:
+    if os.path.exists("dryrun_renamerOnUpdate.txt"):
+        os.remove("dryrun_renamerOnUpdate.txt")
+    log.LogInfo("Dry mode on")
 
+START_TIME = time.time()
 FRAGMENT = json.loads(sys.stdin.read())
 
 FRAGMENT_SERVER = FRAGMENT["server_connection"]
 PLUGIN_DIR = FRAGMENT_SERVER["PluginDir"]
 
-FRAGMENT_SCENE_ID = FRAGMENT["args"].get("hookContext")
-if FRAGMENT_SCENE_ID:
-    FRAGMENT_SCENE_ID = FRAGMENT_SCENE_ID["id"]
+
 PLUGIN_ARGS = FRAGMENT['args'].get("mode")
 
 #log.LogDebug("{}".format(FRAGMENT))
 
 
-def callGraphQL(query, variables=None, raise_exception=True):
+def callGraphQL(query, variables=None):
     # Session cookie for authentication
-    graphql_port = FRAGMENT_SERVER['Port']
+    graphql_port = str(FRAGMENT_SERVER['Port'])
     graphql_scheme = FRAGMENT_SERVER['Scheme']
-    graphql_cookies = {
-        'session': FRAGMENT_SERVER.get('SessionCookie').get('Value')
-    }
+    graphql_cookies = {'session': FRAGMENT_SERVER['SessionCookie']['Value']}
     graphql_headers = {
         "Accept-Encoding": "gzip, deflate, br",
         "Content-Type": "application/json",
@@ -52,9 +56,11 @@ def callGraphQL(query, variables=None, raise_exception=True):
         "Connection": "keep-alive",
         "DNT": "1"
     }
-    graphql_domain = STASH_URL
+    graphql_domain = FRAGMENT_SERVER['Host']
+    if graphql_domain == "0.0.0.0":
+        graphql_domain = "localhost"
     # Stash GraphQL endpoint
-    graphql_url = graphql_scheme + "://" + graphql_domain + ":" + str(graphql_port) + "/graphql"
+    graphql_url = f"{graphql_scheme}://{graphql_domain}:{graphql_port}/graphql"
 
     json = {'query': query}
     if variables is not None:
@@ -62,29 +68,19 @@ def callGraphQL(query, variables=None, raise_exception=True):
     try:
         response = requests.post(graphql_url, json=json, headers=graphql_headers, cookies=graphql_cookies, timeout=20)
     except Exception as e:
-        exit_plugin(err="[FATAL] Exception with GraphQL request. {}".format(e))
+        exit_plugin(err=f"[FATAL] Error with the graphql request {e}")
     if response.status_code == 200:
         result = response.json()
         if result.get("error"):
             for error in result["error"]["errors"]:
-                if raise_exception:
-                    raise Exception("GraphQL error: {}".format(error))
-                else:
-                    log.LogError("GraphQL error: {}".format(error))
-            return None
-        if result.get("errors"):
-            for error in result["errors"]:
-                if raise_exception:
-                    raise Exception("GraphQL error: {}".format(error))
-                else:
-                    log.LogError("GraphQL error: {}".format(error))
+                raise Exception(f"GraphQL error: {error}")
             return None
         if result.get("data"):
             return result.get("data")
     elif response.status_code == 401:
         exit_plugin(err="HTTP Error 401, Unauthorised.")
     else:
-        raise ConnectionError("GraphQL query failed: {} - {}".format(response.status_code, response.content))
+        raise ConnectionError(f"GraphQL query failed: {response.status_code} - {response.content}")
 
 
 def graphql_getScene(scene_id):
@@ -96,6 +92,7 @@ def graphql_getScene(scene_id):
     }
     fragment SceneData on Scene {
         id
+        oshash
         title
         date
         rating
@@ -125,6 +122,15 @@ def graphql_getScene(scene_id):
           id
           name
           gender
+          favorite
+          rating
+        }
+        movies {
+            movie {
+                name
+                date
+            }
+            scene_index
         }
     }
     """
@@ -133,6 +139,66 @@ def graphql_getScene(scene_id):
     }
     result = callGraphQL(query, variables)
     return result.get('findScene')
+
+
+def graphql_findScene(perPage, direc="DESC") -> dict:
+    query = """
+    query FindScenes($filter: FindFilterType) {
+        findScenes(filter: $filter) {
+            count
+            scenes {
+                ...SlimSceneData
+            }
+        }
+    }
+    fragment SlimSceneData on Scene {
+        id
+        oshash
+        title
+        date
+        rating
+        organized
+        path
+        file {
+            video_codec
+            audio_codec
+            width
+            height
+            framerate
+            bitrate
+        }
+        studio {
+          id
+          name
+          parent_studio {
+              id
+              name
+          }
+        }
+        tags {
+          id
+          name
+        }
+        performers {
+          id
+          name
+          gender
+          favorite
+          rating
+        }
+        movies {
+            movie {
+                name
+                date
+            }
+            scene_index
+        }
+    }
+    """
+    # ASC DESC
+    variables = {'filter': {"direction": direc, "page": 1, "per_page": perPage, "sort": "updated_at"}}
+    result = callGraphQL(query, variables)
+    return result.get("findScenes")
 
 
 def graphql_getConfiguration():
@@ -169,38 +235,17 @@ def graphql_getStudio(studio_id):
     return result.get("findStudio")
 
 
-def makeFilename(scene_information, query):
-    new_filename = str(query)
-    for field in TEMPLATE_FIELD:
-        field_name = field.replace("$", "")
-        if field in new_filename:
-            if scene_information.get(field_name):
-                if field == "$performer":
-                    if re.search(r"\$performer[-\s_]*\$title", new_filename) and scene_information.get('title') and PREVENT_TITLE_PERF:
-                        if re.search("^{}".format(scene_information["performer"]), scene_information["title"]):
-                            log.LogInfo("Ignoring the performer field because it's already in start of title")
-                            new_filename = new_filename.replace(field, "")
-                            continue
-                new_filename = new_filename.replace(field, scene_information[field_name])
-            else:
-                new_filename = new_filename.replace(field, "")
-
-    # cleanup
-    new_filename = re.sub(r'[\s_-]+(?=\W{2})', ' ', new_filename)
-    # remove multi space
-    new_filename = re.sub(r'\s+', ' ', new_filename)
-    # remove thing like 'test - ]'
-    for c in ["[", "("]:
-        new_filename = re.sub(r'{}[_\s-]+'.format("\\" + c), c, new_filename)
-    for c in ["]", ")"]:
-        new_filename = re.sub(r'[_\s-]+{}'.format("\\" + c), c, new_filename)
-    # remove () []
-    new_filename = re.sub(r'\(\W*\)|\[\W*\]', '', new_filename)
-    # Remove space at start/end
-    new_filename = new_filename.strip(" -_")
-    # Replace spaces with splitchar
-    new_filename = new_filename.replace(' ', FILENAME_SPLITCHAR)
-    return new_filename
+def graphql_removeScenesTag(id_scenes: list, id_tags: list):
+    query = """
+    mutation BulkSceneUpdate($input: BulkSceneUpdateInput!) {
+        bulkSceneUpdate(input: $input) {
+            id
+        }
+    }
+    """
+    variables = {'input': {"ids": id_scenes, "tag_ids": {"ids": id_tags, "mode": "REMOVE"}}}
+    result = callGraphQL(query, variables)
+    return result
 
 
 def find_diff_text(a: str, b: str):
@@ -218,11 +263,11 @@ def find_diff_text(a: str, b: str):
             addi += s[-1]
             addi_ += 1
     if minus_ > 20 or addi_ > 20:
-        log.LogDebug("Diff Checker: +{}; -{};".format(addi_, minus_))
-        log.LogDebug("OLD: {}".format(a))
-        log.LogDebug("NEW: {}".format(b))
+        log.LogDebug(f"Diff Checker: +{addi_}; -{minus_};")
+        log.LogDebug(f"OLD: {a}")
+        log.LogDebug(f"NEW: {b}")
     else:
-        log.LogDebug("Original: {}\n- Charac: {}\n+ Charac: {}\n  Result: {}".format(a, minus, addi, b))
+        log.LogDebug(f"Original: {a}\n- Charac: {minus}\n+ Charac: {addi}\n  Result: {b}")
     return
 
 
@@ -243,21 +288,641 @@ def has_handle(fpath, all_result=False):
 
 def config_edit(name: str, state: bool):
     found = 0
-    with open(config.__file__, 'r') as file:
+    with open(config.__file__, 'r', encoding='utf8') as file:
         config_lines = file.readlines()
-    with open(config.__file__, 'w') as file_w:
+    with open(config.__file__, 'w', encoding='utf8') as file_w:
         for line in config_lines:
             if name in line.split("=")[0].strip():
-                file_w.write("{} = {}\n".format(name, state))
+                file_w.write(f"{name} = {state}\n")
                 found += 1
             else:
                 file_w.write(line)
     return found
 
 
+def check_longpath(path: str):
+    # Trying to prevent error with long paths for Win10
+    # https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=cmd
+    #TODO remove part until good
+    if len(path) > 240 and not IGNORE_PATH_LENGTH:
+        log.LogError(f"The path is too long {len(path)}")
+        return 1
+
+
+def get_template_filename(scene: dict):
+    template = None
+    # Change by Studio
+    if scene.get("studio") and config.p_studio_templates:
+        template_found = False
+        current_studio = scene.get("studio")
+        if config.studio_templates.get(current_studio['name']):
+            template = config.studio_templates[current_studio['name']]
+            template_found = True
+        # by first Parent found
+        while current_studio.get("parent_studio") and not template_found:
+            if config.studio_templates.get(current_studio.get("parent_studio").get("name")):
+                template = config.studio_templates[current_studio['parent_studio']['name']]
+                template_found = True
+            current_studio = graphql_getStudio(current_studio.get("parent_studio")['id'])
+
+    # Change by Tag
+    if scene.get("tags") and config.tag_templates:
+        for tag in scene['tags']:
+            if config.tag_templates.get(tag['name']):
+                template = config.tag_templates[tag['name']]
+                break
+    return template
+
+
+def get_template_path(scene: dict):
+    template = {"destination": "", "option": [], "opt_details": {}}
+    # Change by Path
+    if config.p_path_templates:
+        for match, job in config.p_path_templates.items():
+            if match in scene["path"]:
+                template["destination"] = job
+                break
+
+    # Change by Studio
+    if scene.get("studio") and config.p_studio_templates:
+        if config.p_studio_templates.get(scene["studio"]["name"]):
+            template["destination"] = config.p_studio_templates[scene["studio"]["name"]]
+        # by Parent
+        if scene["studio"].get("parent_studio"):
+            if config.p_studio_templates.get(scene["studio"]["name"]):
+                template["destination"] = config.p_studio_templates[scene["studio"]["name"]]
+
+    # Change by Tag
+    if scene.get("tags") and config.p_tag_templates:
+        for tag in scene["tags"]:
+            if config.p_tag_templates.get(tag["name"]):
+                template["destination"] = config.p_tag_templates[tag["name"]]
+                break
+
+    if scene.get("tags") and config.p_tag_option:
+        for tag in scene["tags"]:
+            if config.p_tag_option.get(tag["name"]):
+                opt = config.p_tag_option[tag["name"]]
+                template["option"].extend(opt)
+                if opt == "clean_tag":
+                    if template["opt_details"].get("clean_tag"):
+                        template["opt_details"]["clean_tag"].append(tag["id"])
+                    else:
+                        template["opt_details"] = {"clean_tag": [tag["id"]]}
+    return template
+
+
+def sort_performer(lst_use: list, lst_app=[]):
+    for p in lst_use:
+        lst_use[p].sort()
+    for p in lst_use.values():
+        for n in p:
+            if n not in lst_app:
+                lst_app.append(n)
+    return lst_app
+
+
+def extract_info(scene: dict, template: None):
+    # Grabbing things from Stash
+    scene_information = {}
+
+    scene_information['current_path'] = str(scene['path'])
+    # note: contain the dot (.mp4)
+    scene_information['file_extension'] = os.path.splitext(scene_information['current_path'])[1]
+    # note: basename contains the extension
+    scene_information['current_filename'] = os.path.basename(scene_information['current_path'])
+    scene_information['current_directory'] = os.path.dirname(scene_information['current_path'])
+    scene_information['hash'] = scene['oshash']
+
+    if template.get("path"):
+        if "^*" in template["path"]["destination"]:
+            template["path"]["destination"] = template["path"]["destination"].replace("^*", scene_information['current_directory'])
+        scene_information['template_split'] = os.path.normpath(template["path"]["destination"]).split(os.sep)
+    scene_information['current_path_split'] = os.path.normpath(scene_information['current_path']).split(os.sep)
+
+    # Grab Title (without extension if present)
+    if scene.get("title"):
+        # Removing extension if present in title
+        scene_information['title'] = re.sub(fr"{scene_information['file_extension']}$", "", scene['title'])
+        if PREPOSITIONS_REMOVAL:
+            for word in PREPOSITIONS_LIST:
+                scene_information['title'] = re.sub(fr"^{word}[\s_-]", "", scene_information['title'])
+
+    # Grab Date
+    scene_information['date'] = scene.get("date")
+
+    # Grab Rating
+    if scene.get("rating"):
+        scene_information['rating'] = RATING_FORMAT.format(scene['rating'])
+
+    # Grab Performer
+    scene_information['performer_path'] = None
+    if scene.get("performers"):
+        perf_list = []
+        perf_rating = {"5": [], "4": [], "3": [], "2": [], "1": [], "0": []}
+        perf_favorite = {"yes": [], "no": []}
+        for perf in scene['performers']:
+            if perf.get("gender"):
+                if perf['gender'] in PERFORMER_IGNOREGENDER:
+                    continue
+            # path related
+            if template.get("path"):
+                if "inverse_performer" in template["path"]["option"]:
+                    perf["name"] = re.sub(r"([a-zA-Z]+)(\s)([a-zA-Z]+)", r"\3 \1", perf["name"])
+            perf_list.append(perf['name'])
+            if perf.get('rating'):
+                perf_rating[str(perf['rating'])].append(perf['name'])
+            else:
+                perf_rating["0"].append(perf['name'])
+            if perf.get('favorite'):
+                perf_favorite['yes'].append(perf['name'])
+            else:
+                perf_favorite['no'].append(perf['name'])
+            # if the path already contains the name we keep this one
+            if perf["name"] in scene_information['current_path_split'] and scene_information.get('performer_path') is None and PATH_KEEP_ALRPERF:
+                scene_information['performer_path'] = perf["name"]
+                log.LogDebug(f"[PATH] Keeping the current name of the performer '{perf['name']}'")
+        # sort performer
+        if PERFORMER_SORT == "rating":
+            # sort alpha
+            perf_list = sort_performer(perf_rating)
+        elif PERFORMER_SORT == "favorite":
+            perf_list = sort_performer(perf_favorite)
+        elif PERFORMER_SORT == "mix":
+            perf_list = []
+            for p in perf_favorite:
+                perf_favorite[p].sort()
+            for p in perf_favorite.get("yes"):
+                perf_list.append(p)
+            perf_list = sort_performer(perf_rating, perf_list)
+        elif PERFORMER_SORT == "mixid":
+            perf_list = []
+            for p in perf_favorite.get("yes"):
+                perf_list.append(p)
+            for p in perf_rating.values():
+                for n in p:
+                    if n not in perf_list:
+                        perf_list.append(n)
+        elif PERFORMER_SORT == "name":
+            perf_list.sort()
+        if not scene_information['performer_path'] and perf_list:
+            scene_information['performer_path'] = perf_list[0]
+        if len(perf_list) > PERFORMER_LIMIT:
+            if not PERFORMER_LIMIT_KEEP:
+                log.LogInfo(f"More than {PERFORMER_LIMIT} performer(s). Ignoring $performer")
+                perf_list = []
+            else:
+                log.LogInfo(f"Limited the amount of performer to {PERFORMER_LIMIT}")
+                perf_list = perf_list[0: PERFORMER_LIMIT]
+        scene_information['performer'] = PERFORMER_SPLITCHAR.join(perf_list)
+    elif PATH_NOPERFORMER_FOLDER:
+        scene_information['performer_path'] = "NoPerformer"
+        scene_information["performer"] = "NoPerformer"
+
+    # Grab Studio name
+    if scene.get("studio"):
+        if SQUEEZE_STUDIO_NAMES:
+            scene_information['studio'] = scene['studio']['name'].replace(' ', '')
+        else:
+            scene_information['studio'] = scene['studio']['name']
+        scene_information['studio_family'] = scene_information['studio']
+        # Grab Parent name
+        if scene['studio'].get("parent_studio"):
+            if SQUEEZE_STUDIO_NAMES:
+                scene_information['parent_studio'] = scene['studio']['parent_studio']['name'].replace(' ', '')
+            else:
+                scene_information['parent_studio'] = scene['studio']['parent_studio']['name']
+            scene_information['studio_family'] = scene_information['parent_studio']
+
+            studio_p = scene['studio']
+            studio_hierarchy = [scene_information['studio']]
+            while studio_p.get("parent_studio"):
+                studio_p = graphql_getStudio(studio_p['parent_studio']['id'])
+                if studio_p:
+                    studio_hierarchy.append(studio_p['name'])
+            studio_hierarchy.reverse()
+            scene_information['studio_hierarchy'] = studio_hierarchy
+    # Grab Tags
+    if scene.get("tags"):
+        tag_list = []
+        for tag in scene['tags']:
+            # ignore tag in blacklist
+            if tag['name'] in TAGS_BLACKLIST:
+                continue
+            # check if there is a whilelist
+            if len(TAGS_WHITELIST) > 0:
+                if tag['name'] in TAGS_WHITELIST:
+                    tag_list.append(tag['name'])
+            else:
+                tag_list.append(tag['name'])
+        scene_information['tags'] = TAGS_SPLITCHAR.join(tag_list)
+
+    # Grab Height (720p,1080p,4k...)
+    scene_information['resolution'] = 'SD'
+    scene_information['height'] = f"{scene['file']['height']}p"
+    if scene['file']['height'] >= 720:
+        scene_information['resolution'] = 'HD'
+    if scene['file']['height'] >= 2160:
+        scene_information['height'] = '4k'
+        scene_information['resolution'] = 'UHD'
+    if scene['file']['height'] >= 4320:
+        scene_information['height'] = '8k'
+    # For Phone ?
+    if scene['file']['height'] > scene['file']['width']:
+        scene_information['resolution'] = 'VERTICAL'
+
+    if scene.get("movies"):
+        scene_information["movie_title"] = scene["movies"][0]["movie"]["name"]
+        if scene["movies"][0]["movie"].get("date"):
+            scene_information["movie_year"] = scene["movies"][0]["movie"]["date"][0:4]
+        if scene["movies"][0].get("scene_index"):
+            scene_information["movie_index"] = scene["movies"][0]["scene_index"]
+
+    # Grab Video and Audio codec
+    scene_information['video_codec'] = scene['file']['video_codec'].upper()
+    scene_information['audio_codec'] = scene['file']['audio_codec'].upper()
+
+    if scene_information.get("date"):
+        scene_information['year'] = scene_information['date'][0:4]
+
+    if FIELD_WHITESPACE_SEP:
+        for key, value in scene_information.items():
+            if type(value) is str:
+                scene_information[key] = value.replace(" ", FIELD_WHITESPACE_SEP)
+            elif type(value) is list:
+                scene_information[key] = [x.replace(" ", FIELD_WHITESPACE_SEP) for x in value]
+    return scene_information
+
+
+def cleanup_text(text: str):
+    # cleanup
+    new_filename = re.sub(r'[\s_-]+(?=\W{2})', ' ', text)
+    # remove multi space
+    new_filename = re.sub(r'\s+', ' ', new_filename)
+    # remove thing like 'test - ]'
+    for c in ["[", "("]:
+        new_filename = re.sub(r'{}[_\s-]+'.format("\\" + c), c, new_filename)
+    for c in ["]", ")"]:
+        new_filename = re.sub(r'[_\s-]+{}'.format("\\" + c), c, new_filename)
+    # remove () []
+    new_filename = re.sub(r'\(\W*\)|\[\W*\]', '', new_filename)
+    # Remove space at start/end
+    new_filename = new_filename.strip(" -_")
+    return new_filename
+
+
+def makeFilename(scene_information: dict, query: str) -> str:
+    new_filename = str(query)
+    for field in TEMPLATE_FIELD:
+        field_name = field.replace("$", "")
+        if field in new_filename:
+            if field == "$movie_scene":
+                if scene_information.get("movie_index"):
+                    new_filename = new_filename.replace(field, f"scene {scene_information['movie_index']}")
+                else:
+                    new_filename = new_filename.replace(field, "")
+            elif scene_information.get(field_name):
+                if field == "$performer":
+                    if re.search(r"\$performer[-\s_]*\$title", new_filename) and scene_information.get('title') and PREVENT_TITLE_PERF:
+                        if re.search(f"^{scene_information['performer']}", scene_information['title']):
+                            log.LogInfo("Ignoring the performer field because it's already in start of title")
+                            new_filename = new_filename.replace(field, "")
+                            continue
+                new_filename = new_filename.replace(field, scene_information[field_name])
+            else:
+                new_filename = new_filename.replace(field, "")
+
+    if FILENAME_REPLACEWORDS:
+        for old, new in FILENAME_REPLACEWORDS.items():
+            if type(new) is str:
+                new = [new]
+            if len(new) > 1:
+                if new[1] == "regex":
+                    tmp = re.sub(old, new[0], new_filename)
+                    if tmp != new_filename:
+                        log.LogDebug(f"Regex matched: {new_filename} -> {tmp}")
+                else:
+                    if new[1] == "word":
+                        tmp = re.sub(fr'([\s_-])({old})([\s_-])', f'\\1{new[0]}\\3', new_filename)
+                    elif new[1] == "any":
+                        tmp = new_filename.replace(old, new[0])
+                    if tmp != new_filename:
+                        log.LogDebug(f"'{old}' changed with '{new[0]}'")
+            else:
+                tmp = re.sub(fr'([\s_-])({old})([\s_-])', f'\\1{new[0]}\\3', new_filename)
+                if tmp != new_filename:
+                    log.LogDebug(f"'{old}' changed with '{new[0]}'")
+            new_filename = tmp
+
+    new_filename = cleanup_text(new_filename)
+    # Replace spaces with splitchar
+    new_filename = new_filename.replace(' ', FILENAME_SPLITCHAR)
+    return new_filename
+
+
+def makePath(scene_information: dict, query: str) -> str:
+    new_filename = str(query)
+    new_filename = new_filename.replace("$performer", "$performer_path")
+    for field in TEMPLATE_FIELD:
+        field_name = field.replace("$", "")
+        if field in new_filename:
+            if scene_information.get(field_name):
+                new_filename = new_filename.replace(field, scene_information[field_name])
+            else:
+                new_filename = new_filename.replace(field, "")
+    new_filename = cleanup_text(new_filename)
+    return new_filename
+
+
+def create_new_filename(scene_info: dict, template: str):
+    new_filename = makeFilename(scene_info, template) + scene_info['file_extension']
+    if FILENAME_LOWER:
+        new_filename = new_filename.lower()
+
+    # Remove illegal character for Windows
+    new_filename = re.sub('[\\/:"*?<>|]+', '', new_filename)
+
+    if FILENAME_REMOVECHARACTER:
+        new_filename = re.sub(f'[{FILENAME_REMOVECHARACTER}]+', '', new_filename)
+
+    # Trying to remove non standard character
+    if MODULE_UNIDECODE and UNICODE_USE:
+        new_filename = unidecode.unidecode(new_filename, errors='preserve')
+    else:
+        # Using typewriter for Apostrophe
+        new_filename = re.sub("[’‘”“]+", "'", new_filename)
+    return new_filename
+
+
+def remove_consecutive(liste: list):
+    new_list = []
+    for i in range(0, len(liste)):
+        if i != 0 and liste[i] == liste[i - 1]:
+            continue
+        new_list.append(liste[i])
+    return new_list
+
+
+def create_new_path(scene_info: dict, template: dict):
+    # Create the new path
+    # Split the template path
+    if template.get("path"):
+        path_split = scene_info['template_split']
+        path_list = []
+        for part in path_split:
+            if part == "$studio_hierarchy" and scene_info.get("studio_hierarchy"):
+                for p in scene_info["studio_hierarchy"]:
+                    path_list.append(re.sub('["*?<>|#,]+', '', p).strip())
+            else:
+                path_list.append(re.sub('["*?<>|#,]+', '', makePath(scene_info, part)).strip())
+        # Remove blank, empty string
+        path_split = [x for x in path_list if x]
+        # The first character was a seperator, so put it back.
+        if path_list[0] == "":
+            path_split.insert(0, "")
+
+        if PREVENT_CONSECUTIVE:
+            # remove consecutive (/FolderName/FolderName/video.mp4 -> FolderName/video.mp4
+            path_split = remove_consecutive(path_split)
+
+        if "^*" in template["path"]["destination"]:
+            if scene_info['current_directory'] != os.sep.join(path_split):
+                path_split.pop(len(scene_info['current_directory']))
+    else:
+        path_split = scene_info['current_path_split']
+
+    path_edited = os.sep.join(path_split)
+
+    # Using typewriter for Apostrophe
+    new_path = re.sub("[’‘”“]+", "'", path_edited)
+
+    return new_path
+
+
+def connect_db(path: str):
+    try:
+        sqliteConnection = sqlite3.connect(path)
+        log.LogDebug("Python successfully connected to SQLite")
+    except sqlite3.Error as error:
+        log.LogError(f"FATAL SQLITE Error: {error}")
+        return None
+    return sqliteConnection
+
+
+def checking_duplicate_db(stash_db: sqlite3.Connection, scene_info: dict):
+    cursor = stash_db.cursor()
+    # Looking for duplicate path
+    cursor.execute("SELECT id FROM scenes WHERE path LIKE ? AND NOT id=?;", ["%" + scene_info['current_directory'] + "_" + scene_info['new_filename'], scene_info['scene_id']])
+    dupl_check = cursor.fetchall()
+    if len(dupl_check) > 0:
+        for dupl_row in dupl_check:
+            log.LogError(f"Identical path: [{dupl_row[0]}]")
+        log.LogError("Duplicate path detected, check log!")
+        return 1
+
+    # Looking for duplicate filename
+    cursor.execute("SELECT id FROM scenes WHERE path LIKE ? AND NOT id=?;", ["%" + scene_info['new_filename'], scene_info['scene_id']])
+    dupl_check = cursor.fetchall()
+    if len(dupl_check) > 0:
+        for dupl_row in dupl_check:
+            log.LogWarning(f"Duplicate filename: [{dupl_row[0]}]")
+
+    # Looking for exact path
+    cursor.execute("SELECT id FROM scenes WHERE path=? AND NOT id=?;", [scene_info['final_path'], scene_info['scene_id']])
+    dupl_check = cursor.fetchall()
+    if len(dupl_check) > 0:
+        for dupl_row in dupl_check:
+            log.LogError(f"Same path: [{dupl_row[0]}]")
+        return 1
+
+    cursor.close()
+
+
+def db_rename(stash_db: sqlite3.Connection, scene_info):
+    cursor = stash_db.cursor()
+    # Database rename
+    cursor.execute("UPDATE scenes SET path=? WHERE id=?;", [scene_info['final_path'], scene_info['scene_id']])
+    stash_db.commit()
+    # Close DB
+    cursor.close()
+
+
+def file_rename(scene_info: dict, template: dict):
+    # OS Rename
+    if not os.path.isfile(scene_info['current_path']):
+        log.LogWarning(f"[OS] File doesn't exist in your Disk/Drive ({scene_info['current_path']})")
+        return 1
+    # moving/renaming
+    new_dir = os.path.dirname(scene_info['final_path'])
+    if not os.path.exists(new_dir):
+        log.LogInfo(f"Creating folder because it don't exist ({new_dir})")
+        os.makedirs(new_dir)
+    try:
+        shutil.move(scene_info['current_path'], scene_info['final_path'])
+    except PermissionError as err:
+        if "[WinError 32]" in str(err) and MODULE_PSUTIL:
+            log.LogWarning("A process is using this file (Probably FFMPEG), trying to find it ...")
+            # Find which process accesses the file, it's ffmpeg for sure...
+            process_use = has_handle(scene_info['current_path'], PROCESS_ALLRESULT)
+            if process_use:
+                # Terminate the process then try again to rename
+                log.LogDebug(f"Process that uses this file: {process_use}")
+                if PROCESS_KILL:
+                    p = psutil.Process(process_use.pid)
+                    p.terminate()
+                    p.wait(10)
+                    # If process is not terminated, this will create an error again.
+                    os.rename(scene_info['current_path'], scene_info['final_path'])
+                else:
+                    log.LogError("A process prevents renaming the file.")
+                    return 1
+        else:
+            log.LogError(f"Something prevents renaming the file. {err}")
+            return 1
+    # checking if the move/rename work correctly
+    if os.path.isfile(scene_info['final_path']):
+        log.LogInfo("[OS] File Renamed!")
+        if LOGFILE:
+            try:
+                with open(LOGFILE, 'a', encoding='utf-8') as f:
+                    f.write(f"{scene_info['scene_id']}|{scene_info['current_path']}|{scene_info['final_path']}|{scene_info['hash']}\n")
+            except Exception as err:
+                os.rename(scene_info['final_path'], scene_info['current_path'])
+                log.LogError(f"Restoring the original path, error writing the logfile: {err}")
+                return 1
+        if REMOVE_EMPTY_FOLDER:
+            with os.scandir(scene_info['current_directory']) as it:
+                if not any(it):
+                    log.LogInfo(f"Removing empty folder ({scene_info['current_directory']})")
+                    os.remove(scene_info['current_directory'])
+    else:
+        # I don't think it's possible.
+        log.LogError(f"[OS] Failed to rename the file ? {scene_info['final_path']}")
+        return 1
+    if "clean_tag" in template["option"]:
+        graphql_removeScenesTag([scene_info['scene_id']], template["opt_details"]["clean_tag"])
+
+
+def associated_rename(scene_info: dict):
+    if ASSOCIATED_EXT:
+        for ext in ASSOCIATED_EXT:
+            p = os.path.splitext(scene_info['current_path'])[0] + "." + ext
+            p_new = os.path.splitext(scene_info['final_path'])[0] + "." + ext
+            if os.path.isfile(p):
+                try:
+                    os.rename(p, p_new)
+                except Exception as err:
+                    log.LogError(f"Something prevents renaming this file '{p}' - err: {err}")
+                    continue
+            if os.path.isfile(p_new):
+                log.LogInfo(f"[OS] Associate file renamed ({p_new})")
+                if LOGFILE:
+                    try:
+                        with open(LOGFILE, 'a', encoding='utf-8') as f:
+                            f.write(f"{scene_info['scene_id']}|{p}|{p_new}\n")
+                    except Exception as err:
+                        os.rename(p_new, p)
+                        log.LogError(f"Restoring the original name, error writing the logfile: {err}")
+
+
+def renamer(scene_id, db_conn=None):
+    if type(scene_id) is dict:
+        stash_scene = scene_id
+        scene_id = stash_scene['id']
+    elif type(scene_id) is int:
+        stash_scene = graphql_getScene(scene_id)
+
+    if config.only_organized and not stash_scene['organized']:
+        log.LogDebug(f"[{scene_id}] Scene ignored (not organized)")
+        return
+
+    # Tags > Studios > Default
+    template = {}
+    template["filename"] = get_template_filename(stash_scene)
+    template["path"] = get_template_path(stash_scene)
+    log.LogDebug(template)
+    if not template["path"].get("destination"):
+        if config.p_use_default_template:
+            log.LogDebug("[PATH] Using default template")
+            template["path"] = {"destination": config.default_template, "option": [], "opt_details": {}}
+        else:
+            template["path"] = None
+    if not template["filename"] and config.use_default_template:
+        log.LogDebug("[FILENAME] Using default template")
+        template["filename"] = config.default_template
+
+    if not template["filename"] and not template["path"]:
+        log.LogWarning("[{scene_id}] No template for this scene.")
+        return
+
+    #log.LogDebug("Using this template: {}".format(filename_template))
+    scene_information = extract_info(stash_scene, template)
+    log.LogDebug(f"[{scene_id}] Scene information: {scene_information}")
+
+    scene_information['scene_id'] = scene_id
+    scene_information['new_filename'] = create_new_filename(scene_information, template["filename"])
+    scene_information['new_path'] = create_new_path(scene_information, template)
+    if scene_information['new_path'] is None:
+        return
+    scene_information['final_path'] = os.path.join(scene_information['new_path'], scene_information['new_filename'])
+    # check length of path
+    if check_longpath(scene_information['final_path']):
+        if DRY_RUN:
+            with open("dryrun_renamerOnUpdate.txt", 'a', encoding='utf-8') as f:
+                f.write(f"[LENGTH LIMIT] {scene_information['scene_id']}|{scene_information['final_path']}\n")
+        return
+
+    #log.LogDebug(f"Filename: {scene_information['current_filename']} -> {scene_information['new_filename']}")
+    #log.LogDebug(f"Path: {scene_information['current_path']} -> {scene_information['new_path']}")
+
+    if scene_information['final_path'] == scene_information['current_path']:
+        log.LogInfo(f"Everything is ok. ({scene_information['current_filename']})")
+        return
+
+    if scene_information['current_directory'] != scene_information['new_path']:
+        log.LogInfo("File will be moved to another directory")
+        log.LogDebug(f"[OLD path] {scene_information['current_path']}")
+        log.LogDebug(f"[NEW path] {scene_information['final_path']}")
+
+    if scene_information['current_filename'] != scene_information['new_filename']:
+        log.LogInfo("The filename will be changed")
+        if ALT_DIFF_DISPLAY:
+            find_diff_text(scene_information['current_filename'], scene_information['new_filename'])
+        else:
+            log.LogDebug(f"[OLD filename] {scene_information['current_filename']}")
+            log.LogDebug(f"[NEW filename] {scene_information['new_filename']}")
+
+    if DRY_RUN:
+        with open("dryrun_renamerOnUpdate.txt", 'a', encoding='utf-8') as f:
+            f.write(f"{scene_information['scene_id']}|{scene_information['current_path']}|{scene_information['final_path']}\n")
+        return
+    # connect to the db
+    if not db_conn:
+        stash_db = connect_db(STASH_DATABASE)
+        if stash_db is None:
+            return
+    else:
+        stash_db = db_conn
+    # check if there is already a file where the new path is
+    err = checking_duplicate_db(stash_db, scene_information)
+    if err:
+        return
+    # rename file on your disk
+    err = file_rename(scene_information, template)
+    if err:
+        return
+    # rename file on your db
+    db_rename(stash_db, scene_information)
+    if not db_conn:
+        stash_db.close()
+        log.LogInfo("[SQLITE] Database updated and closed!")
+    associated_rename(scene_information)
+
+
 def exit_plugin(msg=None, err=None):
     if msg is None and err is None:
         msg = "plugin ended"
+    log.LogDebug("Execution time: {}s".format(round(time.time() - START_TIME, 5)))
     output_json = {"output": msg, "error": err}
     print(json.dumps(output_json))
     sys.exit()
@@ -265,39 +930,43 @@ def exit_plugin(msg=None, err=None):
 
 if PLUGIN_ARGS:
     log.LogDebug("--Starting Plugin 'Renamer'--")
-    if "enable" in PLUGIN_ARGS:
-        log.LogInfo("Enable hook")
-        success = config_edit("enable_hook", True)
-    elif "disable" in PLUGIN_ARGS:
-        log.LogInfo("Disable hook")
-        success = config_edit("enable_hook", False)
-    if not success:
-        log.LogError("Script failed to change the value of 'enable_hook' variable")
-    exit_plugin("script finished")
+    if "bulk" not in PLUGIN_ARGS:
+        if "enable" in PLUGIN_ARGS:
+            log.LogInfo("Enable hook")
+            success = config_edit("enable_hook", True)
+        elif "disable" in PLUGIN_ARGS:
+            log.LogInfo("Disable hook")
+            success = config_edit("enable_hook", False)
+        elif "dryrun" in PLUGIN_ARGS:
+            if config.dry_run:
+                log.LogInfo("Disable dryrun")
+                success = config_edit("dry_run", False)
+            else:
+                log.LogInfo("Enable dryrun")
+                success = config_edit("dry_run", True)
+        if not success:
+            log.LogError("Script failed to change the value")
+        exit_plugin("script finished")
 else:
     if not config.enable_hook:
         exit_plugin("Hook disabled")
-    else:
-        log.LogDebug("--Starting Hook 'Renamer'--")
+    log.LogDebug("--Starting Hook 'Renamer'--")
+    FRAGMENT_HOOK_TYPE = FRAGMENT["args"]["hookContext"]["type"]
+    FRAGMENT_SCENE_ID = FRAGMENT["args"]["hookContext"]["id"]
 
 STASH_URL = config.stash_url
 LOGFILE = config.log_file
 
-STASH_SCENE = graphql_getScene(FRAGMENT_SCENE_ID)
+#Gallery.Update.Post
+#if FRAGMENT_HOOK_TYPE == "Scene.Update.Post":
+
+
 STASH_CONFIG = graphql_getConfiguration()
-STASH_DATABASE = STASH_CONFIG["general"]["databasePath"]
-TEMPLATE_FIELD = "$date $year $performer $title $height $resolution $parent_studio $studio_family $studio $rating $tags $video_codec $audio_codec".split(" ")
-
-#log.LogDebug("Scene ID: {}".format(FRAGMENT_SCENE_ID))
-#log.LogDebug("Scene Info: {}".format(STASH_SCENE))
-#log.LogDebug("Database Path: {}".format(STASH_DATABASE))
-filename_template = None
-
+STASH_DATABASE = STASH_CONFIG['general']['databasePath']
+TEMPLATE_FIELD = "$date $year $performer_path $performer $title $height $resolution $parent_studio $studio_family $studio $rating $tags $video_codec $audio_codec $movie_title $movie_year $movie_scene".split(" ")
 
 # READING CONFIG
-if config.only_organized and not STASH_SCENE["organized"]:
-    exit_plugin("Scene ignored (not organized)")
-    
+
 ASSOCIATED_EXT = config.associated_extension
 
 FIELD_WHITESPACE_SEP = config.field_whitespaceSeperator
@@ -305,9 +974,12 @@ FIELD_WHITESPACE_SEP = config.field_whitespaceSeperator
 FILENAME_LOWER = config.lowercase_Filename
 FILENAME_SPLITCHAR = config.filename_splitchar
 FILENAME_REMOVECHARACTER = config.removecharac_Filename
+FILENAME_REPLACEWORDS = config.replace_words
 
 PERFORMER_SPLITCHAR = config.performer_splitchar
 PERFORMER_LIMIT = config.performer_limit
+PERFORMER_LIMIT_KEEP = config.performer_limit_keep
+PERFORMER_SORT = config.performer_sort
 PERFORMER_IGNOREGENDER = config.performer_ignoreGender
 PREVENT_TITLE_PERF = config.prevent_title_performer
 
@@ -324,6 +996,8 @@ TAGS_BLACKLIST = config.tags_blacklist
 
 IGNORE_PATH_LENGTH = config.ignore_path_length
 
+PREVENT_CONSECUTIVE = config.prevent_consecutive
+REMOVE_EMPTY_FOLDER = config.remove_emptyfolder
 
 PROCESS_KILL = config.process_kill_attach
 PROCESS_ALLRESULT = config.process_getall
@@ -332,275 +1006,29 @@ UNICODE_USE = config.use_ascii
 ORDER_SHORTFIELD = config.order_field
 ALT_DIFF_DISPLAY = config.alt_diff_display
 
-# ================================================================ #
-#                       RENAMER                                    #
-# Tags > Studios > Default
+PATH_NOPERFORMER_FOLDER = config.path_noperformer_folder
+PATH_KEEP_ALRPERF = config.path_keep_alrperf
 
-# Default
-if config.use_default_template:
-    filename_template = config.default_template
-
-# Change by Studio
-if STASH_SCENE.get("studio") and config.studio_templates:
-    template_found = False
-    current_studio = STASH_SCENE.get("studio")
-    if config.studio_templates.get(current_studio["name"]):
-        filename_template = config.studio_templates[current_studio["name"]]
-        template_found = True
-    # by first Parent found
-    while current_studio.get("parent_studio") and not template_found:
-        if config.studio_templates.get(current_studio.get("parent_studio").get("name")):
-            filename_template = config.studio_templates[current_studio["parent_studio"]["name"]]
-            template_found = True
-        current_studio = graphql_getStudio(current_studio.get("parent_studio")["id"])
-
-# Change by Tag
-if STASH_SCENE.get("tags") and config.tag_templates:
-    for tag in STASH_SCENE["tags"]:
-        if config.tag_templates.get(tag["name"]):
-            filename_template = config.tag_templates[tag["name"]]
-            break
-
-#                           END                                    #
-####################################################################
-
-if not filename_template:
-    exit_plugin("No template for this scene.")
-
-#log.LogDebug("Using this template: {}".format(filename_template))
-
-current_path = str(STASH_SCENE["path"])
-# note: contain the dot (.mp4)
-file_extension = os.path.splitext(current_path)[1]
-# note: basename contains the extension
-current_filename = os.path.basename(current_path)
-current_directory = os.path.dirname(current_path)
-
-# Grabbing things from Stash
-scene_information = {}
-
-# Grab Title (without extension if present)
-if STASH_SCENE.get("title"):
-    # Removing extension if present in title
-    scene_information["title"] = re.sub(r"{}$".format(file_extension), "", STASH_SCENE["title"])
-    if PREPOSITIONS_REMOVAL:
-        for word in PREPOSITIONS_LIST:
-            scene_information["title"] = re.sub(r"^{}[\s_-]".format(word), "", scene_information["title"])
-
-# Grab Date
-scene_information["date"] = STASH_SCENE.get("date")
-
-# Grab Rating
-if STASH_SCENE.get("rating"):
-    scene_information["rating"] = RATING_FORMAT.format(STASH_SCENE["rating"])
-
-# Grab Performer
-if STASH_SCENE.get("performers"):
-    perf_list = []
-    for perf in STASH_SCENE["performers"]:
-        if perf.get("gender"):
-            if perf["gender"] in PERFORMER_IGNOREGENDER:
-                continue
-        perf_list.append(perf["name"])
-    if len(perf_list) > PERFORMER_LIMIT:
-        log.LogInfo("More than {} performer(s). Ignoring $performer".format(PERFORMER_LIMIT))
-        perf_list = []
-    scene_information["performer"] = PERFORMER_SPLITCHAR.join(perf_list)
-
-# Grab Studio name
-if STASH_SCENE.get("studio"):
-    if SQUEEZE_STUDIO_NAMES:
-        scene_information["studio"] = STASH_SCENE["studio"]["name"].replace(' ', '')
-    else:
-        scene_information["studio"] = STASH_SCENE["studio"]["name"]
-    scene_information["studio_family"] = scene_information["studio"]
-    # Grab Parent name
-    if STASH_SCENE["studio"].get("parent_studio"):
-        if SQUEEZE_STUDIO_NAMES:
-            scene_information["parent_studio"] = STASH_SCENE["studio"]["parent_studio"]["name"].replace(' ', '')
-        else:
-            scene_information["parent_studio"] = STASH_SCENE["studio"]["parent_studio"]["name"]
-        scene_information["studio_family"] = scene_information["parent_studio"]
-
-# Grab Tags
-if STASH_SCENE.get("tags"):
-    tag_list = []
-    for tag in STASH_SCENE["tags"]:
-        # ignore tag in blacklist
-        if tag["name"] in TAGS_BLACKLIST:
-            continue
-        # check if there is a whilelist
-        if len(TAGS_WHITELIST) > 0:
-            if tag["name"] in TAGS_WHITELIST:
-                tag_list.append(tag["name"])
-        else:
-            tag_list.append(tag["name"])
-    scene_information["tags"] = TAGS_SPLITCHAR.join(tag_list)
-
-# Grab Height (720p,1080p,4k...)
-scene_information["resolution"] = 'SD'
-scene_information["height"] = "{}p".format(STASH_SCENE["file"]["height"])
-if STASH_SCENE["file"]["height"] >= 720:
-    scene_information["resolution"] = 'HD'
-if STASH_SCENE["file"]["height"] >= 2160:
-    scene_information["height"] = '4k'
-    scene_information["resolution"] = 'UHD'
-if STASH_SCENE["file"]["height"] >= 4320:
-    scene_information["height"] = '8k'
-# For Phone ?
-if STASH_SCENE["file"]["height"] > STASH_SCENE["file"]["width"]:
-    scene_information["resolution"] = 'VERTICAL'
-
-# Grab Video and Audio codec
-scene_information["video_codec"] = STASH_SCENE["file"]["video_codec"].upper()
-scene_information["audio_codec"] = STASH_SCENE["file"]["audio_codec"].upper()
-
-if scene_information.get("date"):
-    scene_information["year"] = scene_information["date"][0:4]
-
-if FIELD_WHITESPACE_SEP:
-    for key, value in scene_information.items():
-        if type(value) is str:
-            scene_information[key] = value.replace(" ", FIELD_WHITESPACE_SEP)
-        elif type(value) is list:
-            scene_information[key] = [x.replace(" ", FIELD_WHITESPACE_SEP) for x in value]
-
-log.LogDebug("[{}] Scene information: {}".format(FRAGMENT_SCENE_ID, scene_information))
-
-
-# Create the new filename
-new_filename = makeFilename(scene_information, filename_template) + file_extension
-if FILENAME_LOWER:
-    new_filename = new_filename.lower()
-
-# Remove illegal character for Windows
-new_filename = re.sub('[\\/:"*?<>|]+', '', new_filename)
-if FILENAME_REMOVECHARACTER:
-    new_filename = re.sub('[{}]+'.format(FILENAME_REMOVECHARACTER), '', new_filename)
-
-# Trying to remove non standard character
-if MODULE_UNIDECODE and UNICODE_USE:
-    new_filename = unidecode.unidecode(new_filename, errors='preserve')
-else:
-    # Using typewriter for Apostrophe
-    new_filename = re.sub("[’‘”“]+", "'", new_filename)
-
-# Replace the old filename by the new in the filepath
-new_path = current_path.rstrip(current_filename) + new_filename
-
-# Trying to prevent error with long paths for Win10
-# https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=cmd
-if len(new_path) > 240 and not IGNORE_PATH_LENGTH:
-    log.LogWarning("Resulting Path is too long ({})...".format(len(new_path)))
-    for word in ORDER_SHORTFIELD:
-        if word not in filename_template:
-            continue
-        filename_template = re.sub(r'\{}[-\s_]*'.format(word), '', filename_template).strip()
-        log.LogDebug("Removing field: {}".format(word))
-        new_filename = makeFilename(scene_information, filename_template) + file_extension
-        new_path = current_path.rstrip(current_filename) + new_filename
-        if len(new_path) < 240:
-            log.LogInfo("Reduced filename to: {}".format(new_filename))
-            break
-    if len(new_path) > 240:
-        exit_plugin(err="Can't shorten path, operation aborted.")
-
-#log.LogDebug("Filename: {} -> {}".format(current_filename,new_filename))
-#log.LogDebug("Path: {} -> {}".format(current_path,new_path))
-
-if (new_path == current_path):
-    exit_plugin("Filename already ok. ({})".format(current_filename))
-
-if ALT_DIFF_DISPLAY:
-    find_diff_text(current_filename, new_filename)
-else:
-    log.LogDebug("[OLD] Filename: {}".format(current_filename))
-    log.LogDebug("[NEW] Filename: {}".format(new_filename))
-
-if DRY_RUN:
-    exit_plugin("Dry run")
-
-# Connect to the DB
-try:
-    sqliteConnection = sqlite3.connect(STASH_DATABASE)
-    cursor = sqliteConnection.cursor()
-    log.LogDebug("Python successfully connected to SQLite")
-except sqlite3.Error as error:
-    exit_plugin(err="FATAL SQLITE Error: {}".format(error))
-
-# Looking for duplicate path
-cursor.execute("SELECT id FROM scenes WHERE path LIKE ? AND NOT id=?;", ["%" + current_directory + "_" + new_filename, FRAGMENT_SCENE_ID])
-dupl_check = cursor.fetchall()
-if len(dupl_check) > 0:
-    for dupl_row in dupl_check:
-        log.LogError("Identical path: [{}]".format(dupl_row[0]))
-    exit_plugin(err="Duplicate path detected, check log!")
-# Looking for duplicate filename
-cursor.execute("SELECT id FROM scenes WHERE path LIKE ? AND NOT id=?;", ["%" + new_filename, FRAGMENT_SCENE_ID])
-dupl_check = cursor.fetchall()
-if len(dupl_check) > 0:
-    for dupl_row in dupl_check:
-        log.LogWarning("Duplicate filename: [{}]".format(dupl_row[0]))
-
-# OS Rename
-if os.path.isfile(current_path):
-    try:
-        os.rename(current_path, new_path)
-    except PermissionError as err:
-        if "[WinError 32]" in str(err) and MODULE_PSUTIL:
-            log.LogWarning("A process is using this file (Probably FFMPEG), trying to find it ...")
-            # Find which process accesses the file, it's ffmpeg for sure...
-            process_use = has_handle(current_path, PROCESS_ALLRESULT)
-            if process_use:
-                # Terminate the process then try again to rename
-                log.LogDebug("Process that uses this file: {}".format(process_use))
-                if PROCESS_KILL:
-                    p = psutil.Process(process_use.pid)
-                    p.terminate()
-                    p.wait(10)
-                    # If process is not terminated, this will create an error again.
-                    os.rename(current_path, new_path)
-                else:
-                    exit_plugin(err="A process prevents renaming the file.")
-        else:
-            log.LogError(err)
-            sys.exit()
-    if os.path.isfile(new_path):
-        log.LogInfo("[OS] File Renamed!")
-        if LOGFILE:
-            with open(LOGFILE, 'a', encoding='utf-8') as f:
-                f.write("{}|{}|{}\n".format(FRAGMENT_SCENE_ID, current_path, new_path))
-    else:
-        # I don't think it's possible.
-        exit_plugin(err="[OS] Failed to rename the file ? {}".format(new_path))
-else:
-    exit_plugin(err="[OS] File doesn't exist in your Disk/Drive ({})".format(current_path))
-
-# Database rename
-cursor.execute("UPDATE scenes SET path=? WHERE id=?;", [new_path, FRAGMENT_SCENE_ID])
-sqliteConnection.commit()
-# Close DB
-cursor.close()
-sqliteConnection.close()
-log.LogInfo("[SQLITE] Database updated and closed!")
-
-if ASSOCIATED_EXT:
-    for ext in ASSOCIATED_EXT:
-        p = os.path.splitext(current_path)[0] + "." + ext
-        p_new = os.path.splitext(new_path)[0] + "." + ext
-        if os.path.isfile(p):
+if PLUGIN_ARGS:
+    if "bulk" in PLUGIN_ARGS:
+        scenes = graphql_findScene(config.batch_number_scene, "ASC")
+        log.LogDebug(f"Count scenes: {len(scenes['scenes'])}")
+        progress = 0
+        progress_step = 1 / len(scenes['scenes'])
+        stash_db = connect_db(STASH_DATABASE)
+        if stash_db is None:
+            exit_plugin()
+        for scene in scenes['scenes']:
+            log.LogDebug(f"** Checking scene: {scene['title']} - {scene['id']} **")
             try:
-                os.rename(p, p_new)
+                renamer(scene, stash_db)
             except Exception as err:
-                log.LogError("Something prevents renaming this file '{}' - err: {}".format(p, err))
-                continue
-        if os.path.isfile(p_new):
-            log.LogInfo("[OS] Associate file renamed ({})".format(p_new))
-            if LOGFILE:
-                try:
-                    with open(LOGFILE, 'a', encoding='utf-8') as f:
-                        f.write("{}|{}|{}\n".format(FRAGMENT_SCENE_ID, p, p_new))
-                except Exception as err:
-                    os.rename(p_new, p)
-                    log.LogError("Restoring the original name, error writing the logfile: {}".format(err))
+                log.LogError(f"error {err}")
+            progress += progress_step
+            log.LogProgress(progress)
+        stash_db.close()
+        log.LogInfo("[SQLITE] Database closed!")
+else:
+    renamer(FRAGMENT_SCENE_ID)
+
 exit_plugin("Successful!")

--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -840,7 +840,6 @@ def renamer(scene_id, db_conn=None):
     template = {}
     template["filename"] = get_template_filename(stash_scene)
     template["path"] = get_template_path(stash_scene)
-    log.LogDebug(template)
     if not template["path"].get("destination"):
         if config.p_use_default_template:
             log.LogDebug("[PATH] Using default template")
@@ -858,6 +857,7 @@ def renamer(scene_id, db_conn=None):
     #log.LogDebug("Using this template: {}".format(filename_template))
     scene_information = extract_info(stash_scene, template)
     log.LogDebug(f"[{scene_id}] Scene information: {scene_information}")
+    log.LogDebug(f"[{scene_id}] Template: {template}")
 
     scene_information['scene_id'] = scene_id
     scene_information['new_filename'] = create_new_filename(scene_information, template["filename"])

--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -671,8 +671,7 @@ def create_new_path(scene_info: dict, template: dict):
         for part in path_split:
             if ":" in part and path_split[0]:
                 path_list.append(part)
-                continue
-            if part == "$studio_hierarchy" and scene_info.get("studio_hierarchy"):
+            elif part == "$studio_hierarchy" and scene_info.get("studio_hierarchy"):
                 for p in scene_info["studio_hierarchy"]:
                     path_list.append(re.sub('[\\/:"*?<>|]+', '', p).strip())
             else:

--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -1026,7 +1026,6 @@ else:
     FRAGMENT_HOOK_TYPE = FRAGMENT["args"]["hookContext"]["type"]
     FRAGMENT_SCENE_ID = FRAGMENT["args"]["hookContext"]["id"]
 
-STASH_URL = config.stash_url
 LOGFILE = config.log_file
 
 #Gallery.Update.Post

--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -952,16 +952,22 @@ def renamer(scene_id, db_conn=None):
             return
     else:
         stash_db = db_conn
-    # check if there is already a file where the new path is
-    err = checking_duplicate_db(stash_db, scene_information)
-    if err:
+    try:
+        # check if there is already a file where the new path is
+        err = checking_duplicate_db(stash_db, scene_information)
+        if err:
+            return
+        # rename file on your disk
+        err = file_rename(scene_information, template)
+        if err:
+            return
+        # rename file on your db
+        db_rename(stash_db, scene_information)
+    except Exception as err:
+        log.LogError(f"Error during database operation ({err})")
+        if not db_conn:
+            stash_db.close()
         return
-    # rename file on your disk
-    err = file_rename(scene_information, template)
-    if err:
-        return
-    # rename file on your db
-    db_rename(stash_db, scene_information)
     if not db_conn:
         stash_db.close()
         log.LogInfo("[SQLITE] Database updated and closed!")

--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -624,7 +624,7 @@ def makeFilename(scene_information: dict, query: str) -> str:
             elif scene_information.get(field_name):
                 if field == "$performer":
                     if re.search(r"\$performer[-\s_]*\$title", new_filename) and scene_information.get('title') and PREVENT_TITLE_PERF:
-                        if re.search(f"^{scene_information['performer']}", scene_information['title']):
+                        if re.search(f"^{scene_information['performer'].lower()}", scene_information['title'].lower()):
                             log.LogInfo("Ignoring the performer field because it's already in start of title")
                             new_filename = re.sub(f'{{\\{field}.+}}|\\{field}', "", new_filename)
                             continue

--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -960,11 +960,11 @@ def renamer(scene_id, db_conn=None):
         # check if there is already a file where the new path is
         err = checking_duplicate_db(stash_db, scene_information)
         if err:
-            return
+            raise Exception("duplicate")
         # rename file on your disk
         err = file_rename(scene_information, template)
         if err:
-            return
+            raise Exception("rename")
         # rename file on your db
         db_rename(stash_db, scene_information)
     except Exception as err:

--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -26,9 +26,14 @@ import config
 import log
 
 DRY_RUN = config.dry_run
+
+if config.log_file:
+    DRY_RUN_FILE = os.path.join(os.path.dirname(config.log_file), "dryrun_renamerOnUpdate.txt")
+
 if DRY_RUN:
-    if os.path.exists("dryrun_renamerOnUpdate.txt"):
-        os.remove("dryrun_renamerOnUpdate.txt")
+    if DRY_RUN_FILE:
+        if os.path.exists(DRY_RUN_FILE):
+            os.remove(DRY_RUN_FILE)
     log.LogInfo("Dry mode on")
 
 START_TIME = time.time()
@@ -894,8 +899,8 @@ def renamer(scene_id, db_conn=None):
     scene_information['final_path'] = os.path.join(scene_information['new_path'], scene_information['new_filename'])
     # check length of path
     if check_longpath(scene_information['final_path']):
-        if DRY_RUN or option_dryrun:
-            with open("dryrun_renamerOnUpdate.txt", 'a', encoding='utf-8') as f:
+        if (DRY_RUN or option_dryrun) and LOGFILE:
+            with open(DRY_RUN_FILE, 'a', encoding='utf-8') as f:
                 f.write(f"[LENGTH LIMIT] {scene_information['scene_id']}|{scene_information['final_path']}\n")
         return
 
@@ -919,8 +924,8 @@ def renamer(scene_id, db_conn=None):
             log.LogDebug(f"[OLD filename] {scene_information['current_filename']}")
             log.LogDebug(f"[NEW filename] {scene_information['new_filename']}")
 
-    if DRY_RUN or option_dryrun:
-        with open("dryrun_renamerOnUpdate.txt", 'a', encoding='utf-8') as f:
+    if (DRY_RUN or option_dryrun) and LOGFILE:
+        with open(DRY_RUN_FILE, 'a', encoding='utf-8') as f:
             f.write(f"{scene_information['scene_id']}|{scene_information['current_path']}|{scene_information['final_path']}\n")
         return
     # connect to the db

--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -531,7 +531,7 @@ def extract_info(scene: dict, template: None):
         scene_information['tags'] = TAGS_SPLITCHAR.join(tag_list)
 
     # Grab Height (720p,1080p,4k...)
-    scene_information['bitrate'] = round(int(scene['file']['bitrate']) / 1000000, 2)
+    scene_information['bitrate'] = str(round(int(scene['file']['bitrate']) / 1000000, 2))
     scene_information['resolution'] = 'SD'
     scene_information['height'] = f"{scene['file']['height']}p"
     if scene['file']['height'] >= 720:

--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -634,7 +634,7 @@ def makePath(scene_information: dict, query: str) -> str:
             if scene_information.get(field_name):
                 new_filename = new_filename.replace(field, scene_information[field_name])
             else:
-                new_filename = new_filename.replace(field, "")
+                new_filename = re.sub(f'{{\\{field}.+}}|\\{field}', "", new_filename)
     new_filename = cleanup_text(new_filename)
     return new_filename
 
@@ -699,6 +699,9 @@ def create_new_path(scene_info: dict, template: dict):
         path_split = scene_info['current_path_split']
 
     path_edited = os.sep.join(path_split)
+
+    if FILENAME_REMOVECHARACTER:
+        path_edited = re.sub(f'[{FILENAME_REMOVECHARACTER}]+', '', path_edited)
 
     # Using typewriter for Apostrophe
     new_path = re.sub("[’‘”“]+", "'", path_edited)
@@ -1024,6 +1027,7 @@ ALT_DIFF_DISPLAY = config.alt_diff_display
 
 PATH_NOPERFORMER_FOLDER = config.path_noperformer_folder
 PATH_KEEP_ALRPERF = config.path_keep_alrperf
+PATH_NON_ORGANIZED = config.p_non_organized
 
 if PLUGIN_ARGS:
     if "bulk" in PLUGIN_ARGS:

--- a/plugins/renamerOnUpdate/renamerOnUpdate.yml
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.yml
@@ -1,14 +1,14 @@
 name: renamerOnUpdate
-description: Rename filename based on a template.
+description: Rename/move filename based on a template.
 url: https://github.com/stashapp/CommunityScripts
-version: 1.5
+version: 2.0
 exec:
   - python
   - "{pluginDir}/renamerOnUpdate.py"
 interface: raw
 hooks:
   - name: hook_rename
-    description: Rename file when you update a scene.
+    description: Rename/move file when you update a scene.
     triggeredBy: 
       - Scene.Update.Post
 tasks:
@@ -20,3 +20,11 @@ tasks:
     description: Enable the hook
     defaultArgs:
       mode: enable
+  - name: 'Dryrun'
+    description: Enable/disable dry-run
+    defaultArgs:
+      mode: dryrun
+  - name: 'Rename scenes'
+    description: Rename all your scenes based on your config.
+    defaultArgs:
+      mode: bulk


### PR DESCRIPTION
### ⚠️ TEST AT YOUR OWN RISK ⚠️ 
###### (just use dry-run, you should be fine 😄 )

## Features

- Template to move your files 
- Bulk task to rename all your scenes with a button #66 
- Dry-run (Do a trial run with no permanent changes)

## New option
- More field (mostly movie related)
- option to sort of the order of performer (Name, ID, Favorite, Rating)
- option to keep performer if it reach the performer limit
- group in template, you can group character with `{}`. kinda #68
  Exemple: `[$studio] {$date -} $title` The `-` is with the date, so if the date is empty, `-` will be remove as well
- Add a option to replace thing in your filename. (#67)

  The second element of the list determine the system used. If you don't put this element, the default is word
`regex`: match a regex, `word`: match a word, `any`: match anything
difference between `word` & `any`: word is between seperator (`space  _  -`), any is anything ('ring' would replace 'during')

  Exemple:   
`"Scene": ["Sc.", "word"]`    - Replace Scene by Sc.
`r"S\d+:E\d+": ["", "regex"]` - Remove Sxx:Ex (x is a digit)
```py
replace_words = {
    r"S\d+:E\d+": ["", "regex"],
    "Be": ["lol", "word"],
    "Do": ["Is", "any"]
}
#Darcy Does It Best - S22:E6 -> Darcy Ises It Best
```

## Deprecation
- Remove field to have the correct length if reached the max .