### PR TITLE
[renamerOnUpdate][renamerTask] Add Month, Day, and Two Digit Year elements for renaming

### DIFF
--- a/plugins/renamer/config.py
+++ b/plugins/renamer/config.py
@@ -1,7 +1,7 @@
 ###################################################################
 #
 # -----------------------------------------------------------------
-# Available: $date $year $performer $title $height $resolution $studio $parent_studio $studio_family $video_codec $audio_codec
+# Available: $date $year $twodigityear $month $day $performer $title $height $resolution $studio $parent_studio $studio_family $video_codec $audio_codec
 # -note:
 # $studio_family: If parent studio exist use it, else use the studio name.
 # $performer: If more than * performers, this field will be ignored. Limit to fix at Settings section below (default: 3)

--- a/plugins/renamer/renamerTask.py
+++ b/plugins/renamer/renamerTask.py
@@ -452,7 +452,9 @@ def renamer(scene_id):
 
     if scene_information.get("date"):
         scene_information["year"] = scene_information["date"][0:4]
-
+        scene_information["twodigityear"] = scene_information["date"][2:4]
+        scene_information["month"] = scene_information["date"][5:7]
+        scene_information["day"] = scene_information["date"][8:10]
 
     # Create the new filename
     new_filename = makeFilename(scene_information, filename_template) + file_extension
@@ -576,7 +578,7 @@ FILE_DRYRUN_RESULT = os.path.join(PLUGIN_DIR, "renamer_scan.txt")
 
 STASH_CONFIG = graphql_getConfiguration()
 STASH_DATABASE = STASH_CONFIG["general"]["databasePath"]
-TEMPLATE_FIELD = "$date $year $performer $title $height $resolution $studio $parent_studio $studio_family $video_codec $audio_codec".split(" ")
+TEMPLATE_FIELD = "$date $year $twodigityear $month $day $performer $title $height $resolution $studio $parent_studio $studio_family $video_codec $audio_codec".split(" ")
 
 # READING CONFIG
 

--- a/plugins/renamerOnUpdate/config.py
+++ b/plugins/renamerOnUpdate/config.py
@@ -4,6 +4,9 @@
 # Available elements for renaming:
 #   $date 
 #   $year 
+#   $twodigityear 
+#   $month 
+#   $day 
 #   $performer 
 #   $title 
 #   $height 

--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -286,7 +286,7 @@ LOGFILE = config.log_file
 STASH_SCENE = graphql_getScene(FRAGMENT_SCENE_ID)
 STASH_CONFIG = graphql_getConfiguration()
 STASH_DATABASE = STASH_CONFIG["general"]["databasePath"]
-TEMPLATE_FIELD = "$date $year $performer $title $height $resolution $parent_studio $studio_family $studio $rating $tags $video_codec $audio_codec".split(" ")
+TEMPLATE_FIELD = "$date $year $twodigityear $month $day $performer $title $height $resolution $parent_studio $studio_family $studio $rating $tags $video_codec $audio_codec".split(" ")
 
 #log.LogDebug("Scene ID: {}".format(FRAGMENT_SCENE_ID))
 #log.LogDebug("Scene Info: {}".format(STASH_SCENE))
@@ -457,6 +457,9 @@ scene_information["audio_codec"] = STASH_SCENE["file"]["audio_codec"].upper()
 
 if scene_information.get("date"):
     scene_information["year"] = scene_information["date"][0:4]
+    scene_information["twodigityear"] = scene_information["date"][2:4]
+    scene_information["month"] = scene_information["date"][5:7]
+    scene_information["day"] = scene_information["date"][8:10]
 
 if FIELD_WHITESPACE_SEP:
     for key, value in scene_information.items():


### PR DESCRIPTION
Adds the following elements to renamerTask and renamerOnUpdate plugins:
Month as $month
Day as $day
Two Digit Year as $twodigityear

This would allow for further customization of date formats such as YY.MM.DD, etc.