### PR TITLE
[GHScraper] Fix support for subdirs

### DIFF
--- a/plugins/GHScraper_Checker/GHScraper_Checker.py
+++ b/plugins/GHScraper_Checker/GHScraper_Checker.py
@@ -129,6 +129,19 @@ with zipfile.ZipFile(zip_path) as z:
             line = bytes()
             # Filename abc.yml
             gh_file = os.path.basename(filename)
+
+            # Filename /scrapers/<subdir>/abc.yml
+            if filename.endswith(f"/scrapers/{gh_file}") == False:
+                log.LogDebug("Subdirectory detected: " + filename)
+                subdir = re.findall('\/scrapers\/(.*)\/.*\.yml', filename)
+
+                if len(subdir) != 1:
+                    log.LogError(f"Unexpected number of matching subdirectories found. Expected 1. Found {len(subdir)}.")
+                    exit(1)
+
+                gh_file = subdir[0] + "/" + gh_file
+
+            log.LogDebug(gh_file)
             path_local = os.path.join(scraper_folder_path, gh_file)
             gh_line = None
             yml_script = None

--- a/plugins/GHScraper_Checker/GHScraper_Checker.py
+++ b/plugins/GHScraper_Checker/GHScraper_Checker.py
@@ -122,6 +122,8 @@ with open(zip_path, "wb") as zip_file:
     zip_file.write(r.content)
 
 with zipfile.ZipFile(zip_path) as z:
+    change_detected = False
+
     for filename in z.namelist():
         #  Only care about the scrapers folders
         if "/scrapers/" in filename and filename.endswith(".yml"):
@@ -180,11 +182,14 @@ with zipfile.ZipFile(zip_path) as z:
                     log.LogError("[Local] Date Error ({}) ".format(gh_file))
                     continue
                 if gh_date > local_date and CHECK_LOG:
+                    change_detected = True
+
                     if yml_script:
                         log.LogInfo("[{}] New version on github (Can be any of the related files)".format(gh_file))
                     else:
                         log.LogInfo("[{}] New version on github".format(gh_file))
             elif GET_NEW_FILE:
+                change_detected = True
                 # File don't exist local so we take the github version.
                 with z.open(filename) as f:
                     scraper_content = f.read()
@@ -193,6 +198,11 @@ with zipfile.ZipFile(zip_path) as z:
                         log.LogInfo("Creating {}".format(gh_file))
                         continue
             elif CHECK_LOG and IGNORE_MISS_LOCAL == False:
+                change_detected = True
+
                 log.LogWarning("[{}] File don't exist locally".format(gh_file))
+
+if change_detected == False:
+    log.LogInfo("Scrapers appear to be in sync with GitHub version.")
 
 os.remove(zip_path)

--- a/plugins/GHScraper_Checker/GHScraper_Checker.yml
+++ b/plugins/GHScraper_Checker/GHScraper_Checker.yml
@@ -1,6 +1,6 @@
 name: GHScraper_Checker
 description: Check the community scraper repo.
-version: 0.1.0
+version: 0.1.1
 url: https://github.com/stashapp/CommunityScripts/tree/main/plugins/GHScraper_Checker
 exec:
   - python


### PR DESCRIPTION
Currently, if/when this script detects a scraper file in a subdirectory, it misreports it as missing in the root scrapers directory and will also write the file there. I've gotten a bit more hands-on time with Python since the last time I contributed stuff in here, but it's definitely still not my strongest language so please let me know if there's any better ways to solve this (regex tends to feel like a code smell to me in situations like this) or if there's gotchas I've missed.

After this I'm kinda leaning towards getting this script able to handle the entirety of the directory. I don't love that, especially as the scrapers get progressively custom, this script is ignoring the python scripts.