### PR TITLE
Timestamp.trade

### DIFF
--- a/plugins/timestampTrade/README.md
+++ b/plugins/timestampTrade/README.md
@@ -1,0 +1,16 @@
+# timestampTrade 
+I've created the api https://timestamp.trade to sync markers between stash instances and xbvr.
+This sits along side other metadata databases like stashdb while we wait for the feature to be added there.
+
+The api does not currently require an api key but one may be required in the future.
+
+Fetching scenes require a stashdb id on the scene.
+Submitting markers does not require a stashid on the scene but it is recommended.
+
+### Installation 
+Move the `timestampTrade` directory into Stash's plugins directory, reload plugins.
+
+### Tasks
+* Submit - Submit markers for all scenes that have markers.
+* Sync - Fetch markers for all scenes with a stash id.
+* Post update hook - Fetch markers for that scene

--- a/plugins/timestampTrade/requirements.txt
+++ b/plugins/timestampTrade/requirements.txt
@@ -1,0 +1,2 @@
+requests
+stashapp-tools

--- a/plugins/timestampTrade/timestampTrade.py
+++ b/plugins/timestampTrade/timestampTrade.py
@@ -1,0 +1,68 @@
+import stashapi.log as log
+from stashapi.stashapp import StashInterface
+import stashapi.marker_parse as mp
+import os
+import sys
+import requests
+import json
+
+per_page = 100
+
+def processScene(s):
+    if len(s['stash_ids']) > 0:
+        for sid in s['stash_ids']:
+            #                print('looking up markers for stash id: '+sid['stash_id'])
+            res = requests.post('https://timestamp.trade/get-markers/' + sid['stash_id'], json=s)
+            md = res.json()
+            if 'marker' in md:
+                log.info(
+                    'api returned something, for scene: ' + s['title'] + ' marker count: ' + str(len(md['marker'])))
+                markers = []
+                for m in md['marker']:
+                    log.debug('-- ' + m['name'] + ", " + str(m['start'] / 1000))
+                    marker = {}
+                    marker["seconds"] = m['start'] / 1000
+                    marker["primary_tag"] = m["tag"]
+                    marker["tags"] = []
+                    marker["title"] = m['name']
+                    markers.append(marker)
+                if len(markers) > 0:
+                    log.info('Saving markers')
+                    mp.import_scene_markers(stash, markers, s['id'], 15)
+
+
+def processAll():
+
+    count=stash.find_scenes(f={"stash_id":{"value":"","modifier":"NOT_NULL"},"has_markers":"false"},filter={"per_page": 1},get_count=True)[0]
+    for r in range(1,int(count/per_page)+1):
+        log.info('processing '+str(r*per_page)+ ' - '+str(count))
+        scenes=stash.find_scenes(f={"stash_id":{"value":"","modifier":"NOT_NULL"},"has_markers":"false"},filter={"page":r,"per_page": per_page})
+        for s in scenes:
+            processScene(s)
+
+def submit():
+    count = stash.find_scenes(f={"has_markers": "true"}, filter={"per_page": 1}, get_count=True)[0]
+    for r in range(1, int(count / per_page) + 2):
+        log.info('processing ' + str((r - 1) * per_page) + ' - ' + str(r * per_page) + ' / ' + str(count))
+        scenes = stash.find_scenes(f={"has_markers": "true"}, filter={"page": r, "per_page": per_page})
+        for s in scenes:
+            print("submitting scene: " + str(s))
+            requests.post('https://timestamp.trade/submit-stash', json=s)
+
+
+
+
+
+json_input = json.loads(sys.stdin.read())
+FRAGMENT_SERVER = json_input["server_connection"]
+stash = StashInterface(FRAGMENT_SERVER)
+if 'mode' in json_input['args']:
+    PLUGIN_ARGS = json_input['args']["mode"]
+    if 'submit' in PLUGIN_ARGS:
+        submit()
+    elif 'process' in PLUGIN_ARGS:
+        processAll()
+elif 'hookContext' in json_input['args']:
+    id=json_input['args']['hookContext']['id']
+    scene=stash.find_scene(id)
+    processScene(scene)

--- a/plugins/timestampTrade/timestampTrade.yml
+++ b/plugins/timestampTrade/timestampTrade.yml
@@ -1,0 +1,22 @@
+name: Timestamp Trade
+description: Sync Markers with timestamp.trade, a new database for sharing markers.
+version: 0.1
+url: https://github.com/stashapp/CommunityScripts/
+exec:
+  - python
+  - "{pluginDir}/timestampTrade.py"
+interface: raw
+hooks:
+  - name: Add Marker to Scene
+    description: Makes Markers checking against timestamp.trade
+    triggeredBy:
+      - Scene.Update.Post
+tasks:
+  - name: 'Submit'
+    description: Submit markers to timestamp.trade
+    defaultArgs:
+      mode: submit
+  - name: 'Sync'
+    description: Get markers for all scenes with a stashid
+    defaultArgs:
+      mode: process


### PR DESCRIPTION
I've created the api https://timestamp.trade to sync markers between stash instances and xbvr.
This sits along side other metadata databases like stashdb while we wait for the feature to be added there.