### PR TITLE
[PathParser] Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Scanning|Scene.Create<br />Gallery.Create<br />Image.Create|[defaultDataForPath]
 Scanning|Scene.Create<br />Gallery.Create|[filenameParser](plugins/filenameParser)|Tries to parse filenames, primarily in {studio}.{year}.{month}.{day}.{performer1firstname}.{performer1lastname}.{performer2}.{title} format, into the respective fields|v0.10
 Scanning|Scene.Create|[titleFromFilename](plugins/titleFromFilename)|Sets the scene title to its filename|v0.17
 Reporting||[TagGraph](plugins/taggrap)|Creates a visual of the Tag relations.|v0.7
+Scanning|Scene.Create|[pathParser](plugins/pathParser)|Updates scene info based on the file path.|v0.17
 
 ## Themes
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Maintenance|Set Scene Cover|[setSceneCoverFromFile](plugins/setSceneCoverFromFil
 Scenes|SceneMarker.Create<br />SceneMarker.Update|[markerTagToScene](plugins/markerTagToScene)|Adds primary tag of Scene Marker to the Scene on marker create/update.|v0.8 ([46bbede](https://github.com/stashapp/stash/commit/46bbede9a07144797d6f26cf414205b390ca88f9))
 Scanning|Scene.Create<br />Gallery.Create<br />Image.Create|[defaultDataForPath](plugins/defaultDataForPath)|Adds configured Tags, Performers and/or Studio to all newly scanned Scenes, Images and Galleries..|v0.8
 Scanning|Scene.Create<br />Gallery.Create|[filenameParser](plugins/filenameParser)|Tries to parse filenames, primarily in {studio}.{year}.{month}.{day}.{performer1firstname}.{performer1lastname}.{performer2}.{title} format, into the respective fields|v0.10
+Scanning|Scene.Create|[pathParser](plugins/pathParser)|Updates scene info based on the file path.|v0.17
 Scanning|Scene.Create|[titleFromFilename](plugins/titleFromFilename)|Sets the scene title to its filename|v0.17
 Reporting||[TagGraph](plugins/taggrap)|Creates a visual of the Tag relations.|v0.7
-Scanning|Scene.Create|[pathParser](plugins/pathParser)|Updates scene info based on the file path.|v0.17
 
 ## Themes
 

--- a/plugins/pathParser/README.md
+++ b/plugins/pathParser/README.md
@@ -1,0 +1,212 @@
+# Path Parser
+
+Updates scene info based on the file path.
+
+## Contents
+* [Hooks](#hooks)
+* [Triggers](#triggers)
+* [Rules](#rules)
+* [Patterns](#patterns)
+* [Fields](#fields)
+* [Examples](#examples)
+
+## Hooks
+
+### Run Rules on scan
+
+Updates scene info whenever a new scene is added.
+
+You can disable this hook by deleting the following section from `pathParser.yml`:
+
+```yml
+hooks:
+  - name: Run Rules on scan
+    description: Updates scene info whenever a new scene is added.
+    triggeredBy: 
+      - Scene.Create.Post
+```
+
+## Triggers
+
+### Create Tags
+
+Adds the \[Run\] and \[Test\] tags.
+
+You can remove this trigger by deleting the following section from `pathParser.yml`:
+
+```yml
+  - name: Create Tags
+    description: Create tags used by the path parser tasks.
+    defaultArgs:
+      task: createTags
+```
+
+### Remove Tags
+
+Removes the \[Run\] and \[Test\] tags.
+
+You can remove this trigger by deleting the following section from `pathParser.yml`:
+
+```yml
+  - name: Remove Tags
+    description: Remove tags used by the path parser tasks.
+    defaultArgs:
+      task: removeTags
+```
+
+### Run Rules
+
+Run rules for scenes containing the \[Run\] tag.
+
+You can remove this trigger by deleting the following section from `pathParser.yml`:
+
+```yml
+  - name: Run Rules
+    description: Run rules for scenes containing the [Run] tag.
+    defaultArgs:
+      task: runRules
+```
+
+### Test Rules
+
+Test rules for scenes containing the \[Test\] tag.
+
+You can remove this trigger by deleting the following section from `pathParser.yml`:
+
+```yml
+  - name: Test Rules
+    description: Test rules for scenes containing the [Test] tag.
+    defaultArgs:
+      task: testRules
+```
+
+## Rules
+
+A single rule must have a name, pattern, and fields:
+
+```jsonc
+{
+  name: 'Your Rule',
+
+  // This pattern would match a scene with the path: folder/folder/file.mp4
+  pattern: [
+    'folder',
+    'folder',
+    'file'
+  ],
+
+  // The matched scene would update it's title and studio
+  fields: {
+    title: 'Scene Title',
+    studio: 'Studio'
+  }
+}
+```
+
+## Patterns
+
+Each entry in pattern will match a folder or the filename (without extension).
+
+Patterns behave differently depending on the type:
+
+| Type     | Format                             | Description                                |
+|:---------|:-----------------------------------|:-------------------------------------------|
+| null     | `null`                             | Matches any value                          |
+| String   | `'string'`                         | Matches a specific value exactly           |
+| RegExp   | `/regex/`                          | Match using a regex<sup>1</sup>            |
+| Array    | `['string1', 'string2', /regex/]`  | Match any one of the sub-patterns          |
+| Function | `function (path) { return path; }` | Match if function returns a non-null value |
+
+1. Parenthesis matches in the regex are able to be used in [field](#fields) replacements.
+
+## Fields
+
+The first matching rule will update the scene with the fields indicated:
+
+| Field      | Format                            |
+| :----------|:----------------------------------|
+| title      | `'New Title'`                     |
+| studio     | `'Studio Name'`                   |
+| performers | `'Performer 1, Performer 2, ...'` |
+| tags       | `'Tag 1, Tag 2, ...'`             |
+
+Matched patterns can be inserted into any field by referencing their indexed value ([see examples](#examples) below).
+
+## Examples
+
+### Specific studio folders with scenes
+
+```js
+{
+  name: 'Specific studio folders with scenes',
+  pattern: [
+    ['Specific Studio', 'Another Studio'], // A specific studio name
+    null // Any filename
+  ],
+  fields: {
+    title: '#1', // 1 refers to the second pattern (filename)
+    studio: '#0' // 0 refers to the first pattern (folder)
+  }
+}
+```
+
+Input: `X:\DCE\Black Adam.mp4`
+
+Output:
+
+0. DCE
+1. Black Adam
+
+### Studio with movie sub-folder and scenes
+
+```js
+{
+  name: 'Specific studio folders with scenes',
+  pattern: [
+    null, // Any studio name
+    /(.+) \(\d{4}\)/, // A sub-folder with 'Movie Title (2022)'
+    /(.+) - \w+ {d}/, // A filename with 'Scene Title - Scene 1'
+  ],
+  fields: {
+    title: '#2',
+    studio: '#0'
+  }
+}
+```
+
+Input: `X:\HBO\House of the Dragon (2022)\House of the Dragon - Episode 1.mp4`
+
+Output:
+
+0. HBO
+1. House of the Dragon
+2. House of the Dragon
+
+### Filename with performers using function
+
+```js
+
+{
+  name: 'Filename with performers using function',
+  pattern: [
+    null, // Any studio name
+    function (path) {
+      var parts = path.split('.');
+      var performers = parts[1].split('&').map(function (performer) { return performer.trim() }).join(',');
+      return [parts[0], performers];
+    }
+  ],
+  fields: {
+    title: '#1',
+    studio: '#0'
+  }
+}
+```
+
+Input: `X:\Prime\The Boys.Karl Urban & Jack Quaid.S01E01.mp4`
+
+Output:
+
+0. Prime
+1. The Boys
+2. Karl Urban,Jack Quaid

--- a/plugins/pathParser/README.md
+++ b/plugins/pathParser/README.md
@@ -30,7 +30,7 @@ hooks:
 
 ### Create Tags
 
-Adds the \[Run\] and \[Test\] tags.
+Adds the \[Run\] and \[Test\] tags (configurable from pathParser.yml).
 
 You can remove this trigger by deleting the following section from `pathParser.yml`:
 
@@ -39,11 +39,13 @@ You can remove this trigger by deleting the following section from `pathParser.y
     description: Create tags used by the path parser tasks.
     defaultArgs:
       task: createTags
+      runTag: '[Run]'
+      testTag: '[Test]'
 ```
 
 ### Remove Tags
 
-Removes the \[Run\] and \[Test\] tags.
+Removes the \[Run\] and \[Test\] tags (configurable from pathParser.yml).
 
 You can remove this trigger by deleting the following section from `pathParser.yml`:
 
@@ -52,32 +54,36 @@ You can remove this trigger by deleting the following section from `pathParser.y
     description: Remove tags used by the path parser tasks.
     defaultArgs:
       task: removeTags
+      runTag: '[Run]'
+      testTag: '[Test]'
 ```
 
 ### Run Rules
 
-Run rules for scenes containing the \[Run\] tag.
+Run rules for scenes containing the \[Run\] tag (configurable from pathParser.yml).
 
 You can remove this trigger by deleting the following section from `pathParser.yml`:
 
 ```yml
   - name: Run Rules
-    description: Run rules for scenes containing the [Run] tag.
+    description: Run rules for scenes containing the run tag.
     defaultArgs:
       task: runRules
+      runTag: '[Run]'
 ```
 
 ### Test Rules
 
-Test rules for scenes containing the \[Test\] tag.
+Test rules for scenes containing the \[Test\] tag (configurable from pathParser.yml).
 
 You can remove this trigger by deleting the following section from `pathParser.yml`:
 
 ```yml
   - name: Test Rules
-    description: Test rules for scenes containing the [Test] tag.
+    description: Test rules for scenes containing the test tag.
     defaultArgs:
       task: testRules
+      testTag: '[Test]'
 ```
 
 ## Rules
@@ -123,12 +129,13 @@ Patterns behave differently depending on the type:
 
 The first matching rule will update the scene with the fields indicated:
 
-| Field      | Format                            |
-| :----------|:----------------------------------|
-| title      | `'New Title'`                     |
-| studio     | `'Studio Name'`                   |
-| performers | `'Performer 1, Performer 2, ...'` |
-| tags       | `'Tag 1, Tag 2, ...'`             |
+| Field       | Format                            |
+| :-----------|:----------------------------------|
+| title       | `'New Title'`                     |
+| studio      | `'Studio Name'`                   |
+| movie_title | `'Movie Name'`                    |
+| performers  | `'Performer 1, Performer 2, ...'` |
+| tags        | `'Tag 1, Tag 2, ...'`             |
 
 Matched patterns can be inserted into any field by referencing their indexed value ([see examples](#examples) below).
 
@@ -138,7 +145,7 @@ Matched patterns can be inserted into any field by referencing their indexed val
 
 ```js
 {
-  name: 'Specific studio folders with scenes',
+  name: 'Studio/Scene',
   pattern: [
     ['Specific Studio', 'Another Studio'], // A specific studio name
     null // Any filename
@@ -161,7 +168,7 @@ Output:
 
 ```js
 {
-  name: 'Specific studio folders with scenes',
+  name: 'Studio/Movie (YEAR)/Scene - Scene #',
   pattern: [
     null, // Any studio name
     /(.+) \(\d{4}\)/, // A sub-folder with 'Movie Title (2022)'
@@ -169,7 +176,8 @@ Output:
   ],
   fields: {
     title: '#2',
-    studio: '#0'
+    studio: '#0',
+    movie_title: '#1'
   }
 }
 ```
@@ -187,7 +195,7 @@ Output:
 ```js
 
 {
-  name: 'Filename with performers using function',
+  name: 'Studio/Scene.Performers.S##E##',
   pattern: [
     null, // Any studio name
     function (path) {

--- a/plugins/pathParser/README.md
+++ b/plugins/pathParser/README.md
@@ -134,6 +134,7 @@ The first matching rule will update the scene with the fields indicated:
 | title       | `'New Title'`                     |
 | studio      | `'Studio Name'`                   |
 | movie_title | `'Movie Name'`                    |
+| scene_index | `'1'`                             |
 | performers  | `'Performer 1, Performer 2, ...'` |
 | tags        | `'Tag 1, Tag 2, ...'`             |
 
@@ -172,12 +173,13 @@ Output:
   pattern: [
     null, // Any studio name
     /(.+) \(\d{4}\)/, // A sub-folder with 'Movie Title (2022)'
-    /(.+) - \w+ {d}/, // A filename with 'Scene Title - Scene 1'
+    /(.+) - \w+ ({d})/, // A filename with 'Scene Title - Scene 1'
   ],
   fields: {
     title: '#2',
     studio: '#0',
-    movie_title: '#1'
+    movie_title: '#1',
+    scene_index: '#3'
   }
 }
 ```
@@ -189,6 +191,7 @@ Output:
 0. HBO
 1. House of the Dragon
 2. House of the Dragon
+3. 1
 
 ### Filename with performers using function
 
@@ -201,20 +204,26 @@ Output:
     function (path) {
       var parts = path.split('.');
       var performers = parts[1].split('&').map(function (performer) { return performer.trim() }).join(',');
-      return [parts[0], performers];
+      var series = /S(\d{2})E(\d{2})/.exec(parts[2]);
+      return [parts[0], performers, parseInt(series[1]), parseInt(series[2])];
     }
   ],
   fields: {
     title: '#1',
-    studio: '#0'
+    studio: '#0',
+    performers: '#2',
+    movie_title: '#1 - Season #3',
+    scene_index: '#4'
   }
 }
 ```
 
-Input: `X:\Prime\The Boys.Karl Urban & Jack Quaid.S01E01.mp4`
+Input: `X:\Prime\The Boys.Karl Urban & Jack Quaid.S06E09.mp4`
 
 Output:
 
 0. Prime
 1. The Boys
 2. Karl Urban,Jack Quaid
+3. 6
+4. 9

--- a/plugins/pathParser/pathParser.js
+++ b/plugins/pathParser/pathParser.js
@@ -468,14 +468,14 @@ function applyRule(sceneId, fields, data)
       value = value.replace('#' + i, data[i]);
     }
 
-    if (DEBUG)
-    {
-      bufferedOutput += field + ': ' + value + '\n';
-    }
-
     switch (field)
     {
       case 'title':
+        if (DEBUG)
+        {
+          bufferedOutput += field + ': ' + value + '\n';
+        }
+
         variables.input['title'] = value;
         any = true;
         continue;
@@ -489,6 +489,7 @@ function applyRule(sceneId, fields, data)
 
         if (DEBUG)
         {
+          bufferedOutput += field + ': ' + value + '\n';
           bufferedOutput += 'studio_id: ' + studioId + '\n';
         }
 
@@ -504,19 +505,41 @@ function applyRule(sceneId, fields, data)
             continue;
           }
 
+          if (!variables.input.hasOwnProperty('movies'))
+          {
+            variables.input['movies'] = [{}];
+          }
+
           if (DEBUG)
           {
+            bufferedOutput += field + ': ' + value + '\n';
             bufferedOutput += 'movie_id: ' + movieId + '\n';
           }
 
-          variables.input['movies'] = [
-            {
-              movie_id: movieId
-            }
-          ];
+          variables.input['movies'][0]['movie_id'] = movieId;
           any = true;
           continue;
       
+      case 'scene_index':
+        var sceneIndex = parseInt(value);
+        if (isNaN(sceneIndex))
+        {
+          continue;
+        }
+
+        if (!variables.input.hasOwnProperty('movies'))
+        {
+          variables.input['movies'] = [{}];
+        }
+
+        if (DEBUG)
+        {
+          bufferedOutput += 'scene_index: ' + sceneIndex + '\n';
+        }
+
+        variables.input['movies'][0]['scene_index'] = sceneIndex;
+        continue;
+
       case 'performers':
         var performers = value.split(',').map(tryGetPerformer).filter(notNull);
         if (performers.length == 0)
@@ -526,6 +549,7 @@ function applyRule(sceneId, fields, data)
 
         if (DEBUG)
         {
+          bufferedOutput += field + ': ' + value + '\n';
           bufferedOutput += 'performer_ids: ' + performers.join(', ') + '\n';
         }
 
@@ -542,6 +566,7 @@ function applyRule(sceneId, fields, data)
 
         if (DEBUG)
         {
+          bufferedOutput += field + ': ' + value + '\n';
           bufferedOutput += 'tag_ids: ' + tags.join(', ') + '\n';
         }
 
@@ -560,6 +585,12 @@ function applyRule(sceneId, fields, data)
     }
 
     return;
+  }
+
+  // Remove movies if movie_id is missing
+  if (variables.input.hasOwnProperty('movies') && !variables.input['movies'][0].hasOwnProperty('movie_id'))
+  {
+    delete variables.input['movies'];
   }
 
   // Apply updates

--- a/plugins/pathParser/pathParser.js
+++ b/plugins/pathParser/pathParser.js
@@ -1,0 +1,662 @@
+// Common Patterns
+var patterns = {
+  movieTitleAndYear: /(.+) \(\d{4}\)/,
+  sceneTitleAndPerformers: /(.+) - ([^\.]+)/
+}
+
+var rules = [
+  {
+    name: 'OnlyFans',
+    pattern: [
+      'OnlyFans',
+      null,
+      null
+    ],
+    fields: {
+      studio: 'OnlyFans',
+      performers: '#1',
+    }
+  },
+  {
+    name: 'Studio & Sub-Studio + Movie & Scenes',
+    pattern: [
+      ['Digital Playground', 'New Sensations'], // Parent Studio
+      studiosWithMovies,
+      patterns.movieTitleAndYear,
+      patterns.sceneTitleAndPerformers
+    ],
+    fields: {
+      title: '#4',
+      studio: '#1',
+      performers: '#5'
+    }
+  },
+  {
+    name: 'Movie & Scenes',
+    pattern: [
+      studiosWithMovies,
+      patterns.movieTitleAndYear,
+      null
+    ],
+    fields: {
+      title: '#2',
+      studio: '#0'
+    }
+  },
+  {
+    name: 'Studio & Sub-Studio + Scenes',
+    pattern: [
+      studiosWithSubStudios, // Parent Studio
+      null, // Studio name (any)
+      patterns.sceneTitleAndPerformers
+    ],
+    fields: {
+      title: '#3',
+      studio: '#2'
+    }
+  },
+  {
+    name: 'Studio + Scenes',
+    pattern: [
+      null, // Studio name (any)
+      patterns.sceneTitleAndPerformers
+    ],
+    fields: {
+      title: '#1',
+      studio: '#0',
+      performers: '#2',
+    }
+  },
+];
+
+/* ----------------------------------------------------------------------------
+// DO NOT EDIT BELOW!
+---------------------------------------------------------------------------- */
+function main()
+{
+  try
+  {
+    switch (getTask(input.Args))
+    {
+      case 'createTags':
+        createTags(['[Run]', '[Test]']);
+        break;
+
+      case 'removeTags':
+        removeTags(['[Run]', '[Test]']);
+        break;
+
+      case 'runRules':
+        initBasePaths();
+        runRules('[Run]');
+        break;
+
+      case 'testRules':
+        DEBUG = true;
+        initBasePaths();
+        runRules('[Test]');
+        break;
+
+      case 'scene':
+        var id = getId(input.Args);
+        initBasePaths();
+        matchRuleWithSceneId(id, applyRule);
+        break;
+
+      case 'image':
+        var id = getId(input.Args);
+        initBasePaths();
+        break;
+
+      default:
+        throw 'Unsupported task';
+    }
+  }
+  catch (e)
+  {
+    return { Output: 'error', Error: e };
+  }
+
+  return { Output: 'ok' };
+}
+
+// Determine task based on input args
+function getTask(inputArgs)
+{
+  if (inputArgs.hasOwnProperty('task'))
+  {
+    return inputArgs.task;
+  }
+  
+  if (!inputArgs.hasOwnProperty('hookContext'))
+  {
+    return;
+  }
+
+  switch (inputArgs.hookContext.type)
+  {
+    case 'Scene.Create.Post':
+      return 'scene';
+    
+    case 'Image.Create.Post':
+      return 'image';
+  }
+}
+
+// Get stash paths from configuration
+function initBasePaths()
+{
+  var query ='\
+  query Query {\
+    configuration {\
+      general {\
+        stashes {\
+          path\
+        }\
+      }\
+    }\
+  }';
+
+  var result = gql.Do(query);
+  if (!result.configuration)
+  {
+    throw 'Unable to get library paths';
+  }
+
+  BASE_PATHS = result.configuration.general.stashes.map(function (stash)
+  {
+    return stash.path;
+  });
+
+  if (BASE_PATHS == null || BASE_PATHS.length == 0)
+  {
+    throw 'Unable to get library paths';
+  }
+}
+
+// Create tag if it does not already exist
+function createTags(tags)
+{
+  var query ='\
+  mutation TagCreate($input: TagCreateInput!) {\
+    tagCreate(input: $input) {\
+      id\
+    }\
+  }';
+
+  tags.forEach(function (tag)
+  {
+    if (getTagId(tag) !== null)
+    {
+      return;
+    }
+
+    var variables = {
+      input: {
+        name: tag
+      }
+    };
+
+    var result = gql.Do(query, variables);
+    if (!result.tagCreate)
+    {
+      throw 'Could not create tag ' + tag;
+    }
+  });
+}
+
+// Remove tags if it already exists
+function removeTags(tags)
+{
+  tags.forEach(function (tag)
+  {
+    var tagId = getTagId(tag);
+    if (tagId === null)
+    {
+      return;
+    }
+
+    var query = '\
+    mutation TagsDestroy($ids: [ID!]!) {\
+      tagsDestroy(ids: $ids)\
+    }';
+
+    var variables = {
+      ids: [ tagId ]
+    };
+
+    var result = gql.Do(query, variables);
+    if (!result.tagsDestroy)
+    {
+      throw 'Unable to remove tag ' + tag;
+    }
+  });
+}
+
+// Run rules for scenes containing tag
+function runRules(tag)
+{
+  var tagId = getTagId(tag);
+  if (tagId === null)
+  {
+    throw 'Tag ' + tag + ' does not exist';
+  }
+
+  var query = '\
+  query FindScenes($sceneFilter: SceneFilterType) {\
+    findScenes(scene_filter: $sceneFilter) {\
+      scenes {\
+        id\
+      }\
+    }\
+  }';
+
+  var variables = {
+    sceneFilter: {
+      tags: {
+        value: tagId,
+        modifier: 'INCLUDES'
+      }
+    }
+  };
+
+  var result = gql.Do(query, variables);
+  if (!result.findScenes || result.findScenes.scenes.length == 0)
+  {
+    throw 'No scenes found with tag ' + tag;
+  }
+
+  result.findScenes.scenes.forEach(function (scene)
+  {
+    matchRuleWithSceneId(scene.id, applyRule);
+  });
+}
+
+// Get scene/image id from input args
+function getId(inputArgs)
+{
+  if ((id = inputArgs.hookContext.id) == null)
+  {
+    throw 'Input is missing id';
+  }
+
+  return id;
+}
+
+// Apply callback function to first matching rule for id
+function matchRuleWithSceneId(sceneId, cb)
+{
+  var query = '\
+  query FindScene($findSceneId: ID) {\
+    findScene(id: $findSceneId) {\
+      files {\
+        path\
+      }\
+    }\
+  }';
+
+  var variables = {
+    findSceneId: sceneId
+  }
+
+  var result = gql.Do(query, variables);
+  if (!result.findScene || result.findScene.files.length == 0)
+  {
+    throw 'Missing scene for id: ' + sceneId;
+  }
+
+  for (var i = 0; i < result.findScene.files.length; i++)
+  {
+    try
+    {
+      matchRuleWithPath(sceneId, result.findScene.files[i].path, cb);
+      
+      if (DEBUG && bufferedOutput !== null && bufferedOutput !== '')
+      {
+        log.Info('[PathParser] ' + bufferedOutput);
+      }
+
+      return;
+    }
+    catch (e)
+    {
+      continue;
+    }
+  }
+  
+  if (DEBUG && bufferedOutput !== null && bufferedOutput !== '')
+  {
+    log.Info('[PathParser] ' + bufferedOutput);
+  }
+
+  throw 'No rule matches id: ' + sceneId;
+}
+
+// Apply callback to first matching rule for path
+function matchRuleWithPath(sceneId, path, cb)
+{
+  // Remove base path
+  for (var i = 0; i < BASE_PATHS.length; i++)
+  {
+    if (path.slice(0, BASE_PATHS[i].length) === BASE_PATHS[i])
+    {
+      path = path.slice(BASE_PATHS[i].length);
+    }
+  }
+
+  if (DEBUG)
+  {
+    bufferedOutput = path + '\n';
+  }
+
+  // Split paths into parts
+  var parts = path.split(/[\\/]/);
+
+  // Remove extension from filename
+  parts[parts.length - 1] = parts[parts.length - 1].slice(0, parts[parts.length - 1].lastIndexOf('.'));
+
+  for (var i = 0; i < rules.length; i++)
+  {
+    var sceneData = testRule(rules[i].pattern, parts);
+    if (sceneData !== null)
+    {
+      if (DEBUG)
+      {
+        bufferedOutput += 'Rule: ' + rules[i].name + '\n';
+      }
+
+      log.Debug('[PathParser] Rule: ' + rules[i].name + '\nPath: ' + path);
+      cb(sceneId, rules[i].fields, sceneData);
+      return;
+    }
+  }
+
+  bufferedOutput += 'No matching rule!';
+  throw 'No matching rule for path: ' + path;
+}
+
+// Test single rule
+function testRule(pattern, parts)
+{
+  if (pattern.length !== parts.length)
+  {
+    return null;
+  }
+
+  var matchedParts = [];
+  for (var i = 0; i < pattern.length; i++)
+  {
+    if ((subMatches = testPattern(pattern[i], parts[i])) == null)
+    {
+      return null;
+    }
+
+    matchedParts = [].concat(matchedParts, subMatches);
+  }
+
+  return matchedParts;
+}
+
+function testPattern(pattern, part)
+{
+  // Match anything
+  if (pattern == null)
+  {
+    return [part];
+  }
+
+  // Simple match
+  if (typeof pattern === 'string')
+  {
+    if (pattern === part)
+    {
+      return [part];
+    }
+
+    return null;
+  }
+
+  // Predicate match
+  if (typeof pattern == 'function')
+  {
+    try
+    {
+      var results = pattern(part);
+      if (results !== null)
+      {
+        return results;
+      }
+    }
+    catch (e)
+    {
+      throw e;
+    }
+
+    return null;
+  }
+
+  // Array match
+  if (pattern instanceof Array)
+  {
+    for (var i = 0; i < pattern.length; i++)
+    {
+      if ((results = testPattern(pattern[i], part)) != null)
+      {
+        return results;
+      }
+    }
+
+    return null;
+  }
+
+  // RegExp match
+  if (pattern instanceof RegExp)
+  {
+    var results = pattern.exec(part);
+    if (results === null)
+    {
+      return null;
+    }
+
+    return results.slice(1);
+  }
+}
+
+// Apply rule
+function applyRule(sceneId, fields, data)
+{
+  var values = {};
+
+  for (var field in fields)
+  {
+    var value = fields[field];
+    for (var j = data.length - 1; j >= 0; j--)
+    {
+      value = value.replace('#' + j, data[j]);
+    }
+
+    if (DEBUG)
+    {
+      bufferedOutput += field + ': ' + value + '\n';
+    }
+
+    values[field] = value;
+  }
+
+  // Test only
+  if (DEBUG)
+  {
+    return;
+  }
+
+  // Apply updates
+  var query = '\
+  mutation Mutation($input: SceneUpdateInput!) {\
+    sceneUpdate(input: $input) {\
+      id\
+    }\
+  }';
+
+  var variables = {
+    input: {
+      id: sceneId
+    }
+  };
+
+  var any = false;
+  for (var field in values)
+  {
+    switch (field)
+    {
+      case 'title':
+        variables.input['title'] = values[field];
+        any = true;
+        break;
+
+      case 'studio':
+        var studioId = getStudioId(values[field]);
+        if (studioId != null)
+        {
+          variables.input['studio_id'] = getStudioId(values[field]);
+          any = true;
+        }
+
+        break;
+      
+      case 'performers':
+        var performers = values[field].split(',').map(getPerformerId).filter(notNull);
+        if (performers.length != 0)
+        {
+          variables.input['performer_ids'] = performers;
+          any = true;
+        }
+
+        break;
+
+      case 'tags':
+        var tags = values[field].split(',').map(getTagId).filter(notNull);
+        if (tags.length != 0)
+        {
+          variables.input['tag_ids'] = tags;
+          any = true;
+        }
+
+        break;
+    }
+  }
+
+  if (!any)
+  {
+    throw 'No fields to update for scene ' + sceneId;
+  }
+
+  var result = gql.Do(query, variables);
+  if (!result.sceneUpdate)
+  {
+    throw 'Unable to update scene ' + sceneId;
+  }
+}
+
+// Returns true for not null elements
+function notNull(ele)
+{
+  return ele != null;
+}
+
+// Get studio id from studio name
+function getStudioId(studio)
+{
+  var query = '\
+  query FindStudios($studioFilter: StudioFilterType) {\
+    findStudios(studio_filter: $studioFilter) {\
+      studios {\
+        id\
+      }\
+      count\
+    }\
+  }';
+
+  var variables = {
+    studioFilter: {
+      name: {
+        value: studio.trim(),
+        modifier: 'EQUALS'
+      }
+    }
+  };
+
+  var result = gql.Do(query, variables);
+  if (!result.findStudios || result.findStudios.count == 0)
+  {
+    return;
+  }
+
+  return result.findStudios.studios[0].id;
+}
+
+// Get performer id from performer name
+function getPerformerId(performer)
+{
+  var query = '\
+  query FindPerformers($performerFilter: PerformerFilterType) {\
+    findPerformers(performer_filter: $performerFilter) {\
+      performers {\
+        id\
+      }\
+      count\
+    }\
+  }';
+
+  var variables = {
+    performerFilter: {
+      name: {
+        value: performer.trim(),
+        modifier: 'EQUALS'
+      }
+    }
+  };
+
+  var result = gql.Do(query, variables);
+  if (!result.findPerformers || result.findPerformers.count == 0)
+  {
+    return;
+  }
+
+  return result.findPerformers.performers[0].id;
+}
+
+// Get tag id from tag name
+function getTagId(tag)
+{
+  var query ='\
+  query FindTags($tagFilter: TagFilterType) {\
+    findTags(tag_filter: $tagFilter) {\
+      tags {\
+        id\
+      }\
+      count\
+    }\
+  }';
+
+  var variables = {
+    tagFilter: {
+      name: {
+        value: tag.trim(),
+        modifier: 'EQUALS'
+      }
+    }
+  };
+
+  var result = gql.Do(query, variables);
+  if (!result.findTags || result.findTags.count == 0)
+  {
+    return;
+  }
+
+  return result.findTags.tags[0].id;
+}
+
+var DEBUG = false;
+var BASE_PATHS = [];
+var bufferedOutput = '';
+main();

--- a/plugins/pathParser/pathParser.js
+++ b/plugins/pathParser/pathParser.js
@@ -6,65 +6,28 @@ var patterns = {
 
 var rules = [
   {
-    name: 'OnlyFans',
+    name: 'Rule 1',
     pattern: [
-      'OnlyFans',
+      'Specific Studio',
       null,
       null
     ],
     fields: {
-      studio: 'OnlyFans',
-      performers: '#1',
+      studio: '#0',
+      title: '#2',
     }
   },
   {
-    name: 'Studio & Sub-Studio + Movie & Scenes',
+    name: 'Rule 2',
     pattern: [
-      ['Digital Playground', 'New Sensations'], // Parent Studio
-      studiosWithMovies,
+      ['One Studio', 'Another Studio'],
       patterns.movieTitleAndYear,
       patterns.sceneTitleAndPerformers
-    ],
-    fields: {
-      title: '#4',
-      studio: '#1',
-      performers: '#5'
-    }
-  },
-  {
-    name: 'Movie & Scenes',
-    pattern: [
-      studiosWithMovies,
-      patterns.movieTitleAndYear,
-      null
     ],
     fields: {
       title: '#2',
-      studio: '#0'
-    }
-  },
-  {
-    name: 'Studio & Sub-Studio + Scenes',
-    pattern: [
-      studiosWithSubStudios, // Parent Studio
-      null, // Studio name (any)
-      patterns.sceneTitleAndPerformers
-    ],
-    fields: {
-      title: '#3',
-      studio: '#2'
-    }
-  },
-  {
-    name: 'Studio + Scenes',
-    pattern: [
-      null, // Studio name (any)
-      patterns.sceneTitleAndPerformers
-    ],
-    fields: {
-      title: '#1',
       studio: '#0',
-      performers: '#2',
+      performers: '#3'
     }
   },
 ];

--- a/plugins/pathParser/pathParser.yml
+++ b/plugins/pathParser/pathParser.yml
@@ -15,15 +15,21 @@ tasks:
     description: Create tags used by the path parser tasks.
     defaultArgs:
       task: createTags
+      runTag: '[Run]'
+      testTag: '[Test]'
   - name: Remove Tags
     description: Remove tags used by the path parser tasks.
     defaultArgs:
       task: removeTags
+      runTag: '[Run]'
+      testTag: '[Test]'
   - name: Run Rules
-    description: Run rules for scenes containing the [Run] tag.
+    description: Run rules for scenes containing the run tag.
     defaultArgs:
       task: runRules
+      runTag: '[Run]'
   - name: Test Rules
-    description: Test rules for scenes containing the [Test] tag.
+    description: Test rules for scenes containing the test tag.
     defaultArgs:
       task: testRules
+      testTag: '[Test]'

--- a/plugins/pathParser/pathParser.yml
+++ b/plugins/pathParser/pathParser.yml
@@ -1,0 +1,29 @@
+# example plugin config
+name: Path Parser
+description: Updates scene info based on the file path.
+version: 1.0
+exec:
+  - pathParser.js
+interface: js
+hooks:
+  - name: Run Rules on scan
+    description: Updates scene info whenever a new scene is added.
+    triggeredBy: 
+      - Scene.Create.Post
+tasks:
+  - name: Create Tags
+    description: Create tags used by the path parser tasks.
+    defaultArgs:
+      task: createTags
+  - name: Remove Tags
+    description: Remove tags used by the path parser tasks.
+    defaultArgs:
+      task: removeTags
+  - name: Run Rules
+    description: Run rules for scenes containing the [Run] tag.
+    defaultArgs:
+      task: runRules
+  - name: Test Rules
+    description: Test rules for scenes containing the [Test] tag.
+    defaultArgs:
+      task: testRules


### PR DESCRIPTION
Path Parser shares some similarities with filenameParser and defaultDataForPath.

Unlike those examples, it allows more advanced matching capabilities against the file path for scenes and can update scene attributes based on sub-expression in the path.

For example, if there is a folder for a movie named "Movie Name (2010)" and the scene is split into multiple files "Scene Title - Scene [N].mp4" it can extract/update Movie Name and Scene Title.

It supports updating scenes tagged with [Run], testing rules against scenes tagged with [Test], and automatically updating scenes as they are scanned.