### PR TITLE
[renamerOnUpdate] Perform a stricter check in config_edit to avoid breaking the config

### DIFF
--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -342,7 +342,7 @@ def config_edit(name: str, state: bool):
         with open(config.__file__, 'w', encoding='utf8') as file_w:
             for line in config_lines:
                 if len(line.split("=")) > 1:
-                    if name in line.split("=")[0].strip():
+                    if name == line.split("=")[0].strip():
                         file_w.write(f"{name} = {state}\n")
                         found += 1
                         continue

--- a/plugins/renamerOnUpdate/renamerOnUpdate.yml
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.yml
@@ -1,7 +1,7 @@
 name: renamerOnUpdate
 description: Rename/move filename based on a template.
 url: https://github.com/stashapp/CommunityScripts
-version: 2.3
+version: 2.3.1
 exec:
   - python
   - "{pluginDir}/renamerOnUpdate.py"


### PR DESCRIPTION
Because this check was using `in`, using the Dry Run setting from inside the Stash UI was destroying the `dry_run_append` config value (by making it another `dry_run` value), thereby breaking the config. As it turns out `dry_run` is both in `dry_run` **and** `dry_run_append`. `config_edit` appears to only be used in cases with strict config value matching so I don't expect this loose comparison is an expected behavior.