### PR TITLE
Gallery DateParser - Parse dates from filenames & path for galleries

### DIFF
--- a/plugins/DateParser/date_parser.py
+++ b/plugins/DateParser/date_parser.py
@@ -1,0 +1,69 @@
+import sys, json
+from pathlib import Path
+
+import stashapi.log as log
+from stashapi.stashapp import StashInterface, stashapp_gql_fragments
+import re
+from dateparser import parse
+from datetime import datetime
+
+def main():
+	global stash
+	global pattern
+
+	pattern = re.compile(r"\D(\d{4}|\d{1,2})[\._\- /\\](\d{1,2}|[a-zA-Z]{3,}\.*)[\._\- /\\](\d{4}|\d{1,2})\D")
+	json_input = json.loads(sys.stdin.read())
+	mode_arg = json_input['args']['mode']
+
+	stash = StashInterface(json_input["server_connection"],fragments=[stashapp_gql_fragments.DEVELOP])
+
+	match mode_arg:
+		case "gallery":
+			find_date_for_galleries()
+	
+	#log.exit("ok")
+
+
+
+def find_date_for_galleries():
+
+	galleries = stash.find_galleries(f={
+		"is_missing": "date",
+		"path": {
+			"modifier": "MATCHES_REGEX",
+			"value": ".zip$"
+		},
+		"file_count": {
+			"modifier": "EQUALS",
+			"value": 1
+		}
+	})
+
+
+	total = len(galleries)
+
+	log.info(f"Found {total} galleries")
+
+	for i, gallery in enumerate(galleries):
+		log.progress(i/total)
+		acceptableDate = None
+		for file in gallery.get("files", []):
+			for match in pattern.finditer(file["path"]):
+				g1 = match.group(1)
+				g2 = match.group(2)
+				g3 =match.group(3)
+				temp = parse(g1+" "+g2+" "+g3)
+				if temp:
+					acceptableDate = temp.strftime("%Y-%m-%d")
+		if acceptableDate:
+			log.info("Gallery ID ("+gallery.get("id") + ") has matched the date : "+acceptableDate)
+			updateObject = {
+				"id":gallery.get("id"),
+				"date":acceptableDate
+			}
+			stash.update_gallery(updateObject)
+				
+
+
+if __name__ == '__main__':
+	main()

--- a/plugins/DateParser/date_parser.yml
+++ b/plugins/DateParser/date_parser.yml
@@ -1,0 +1,14 @@
+name: Date Parser
+description: Find date in path or filename and add it
+version: 0.1
+exec:
+  - python
+  - "{pluginDir}/date_parser.py"
+interface: raw
+tasks:
+  - name: Find gallery dates
+    description: Add the date on galleries based on their path
+    defaultArgs:
+      mode: gallery
+
+      

--- a/plugins/DateParser/requirements.txt
+++ b/plugins/DateParser/requirements.txt
@@ -1,0 +1,14 @@
+certifi==2022.9.24
+charset-normalizer==2.1.1
+dateparser==1.1.3
+idna==3.4
+python-dateutil==2.8.2
+pytz==2022.6
+pytz-deprecation-shim==0.1.0.post0
+regex==2022.3.2
+requests==2.28.1
+six==1.16.0
+stashapp-tools==0.2.14
+tzdata==2022.6
+tzlocal==4.2
+urllib3==1.26.12


### PR DESCRIPTION
Simple plugin that add a new task allowing you to scan galleries without a date and try to find the date from its path (inclusing filename).
Example working date : 
Oct. 15, 2002
15 October 2022
15/10/2022
15/10/22
15-10-2022
etc

Require stashapi and dateParser. Requirement.txt included
