### PR TITLE
[plugin][markerTagToScene] Adding task option, enabling copy of ALL marker tags instead of only primary

### DIFF
--- a/plugins/markerTagToScene/markerTagToScene.js
+++ b/plugins/markerTagToScene/markerTagToScene.js
@@ -1,3 +1,6 @@
+//config
+var ALL_MARKER_TAGS = false;
+
 function ok() {
     return {
         output: "ok"
@@ -5,36 +8,69 @@ function ok() {
 }
 
 function main() {
-    var hookContext = input.Args.hookContext;
-    var opInput = hookContext.input;
-    var primaryTagID = opInput.primary_tag_id;
-    var sceneID = opInput.scene_id;
+    // Check if running task, or hook triggered
+    if (input.args.mode === "updateAllScenes") {
+        // running task
+        var totalScenes;
+        var checkedScenes = 0;
+        var pageSize = 100;
+        var currentPage = 1;
+        var modifiedScenes = 0;
+        do {
+            var result = getScenesWithTagsAndMarkers(pageSize, currentPage)
+            totalScenes = result.count;
+            checkedScenes += pageSize;
+            currentPage++;
+            var scenes = result.scenes;
 
-    // we can't currently find scene markers. If it's not in the input
-    // then just return
-    if (!primaryTagID || !sceneID) {
-        // just return
-        return ok();
-    }
+            for (var i = 0; i < scenes.length; i++) {
+                var scene = scenes[i];
+                var sceneTagIDs = scene.tags.map(function (tag) { return tag.id });
+                var markerTags = [];
+                scene.scene_markers.forEach(function (marker) {
+                    markerTags.push(marker.primary_tag.id);
+                    if (ALL_MARKER_TAGS) {
+                        markerTags = markerTags.concat(marker.tags.map(function (tag) {
+                            return tag.id
+                        }));
+                    }
+                });
+                var newSceneTags = concatAndDeduplicate(sceneTagIDs, markerTags);
+                if (newSceneTags.length > sceneTagIDs.length) {
+                    // This scene is going to get new tags
+                    modifiedScenes++;
+                    setSceneTags(scene.id, newSceneTags)
+                }
+            }
 
-    // get the existing scene tags
-    var sceneTags = getSceneTags(sceneID);
-    var tagIDs = [];
-    for (var i = 0; i < sceneTags.length; ++i) {
-        var tagID = sceneTags[i].id;
-        if (tagID == primaryTagID) {
-            log.Debug("primary tag already exists on scene");
-            return;
+        } while (checkedScenes < totalScenes)
+
+        log.Info("Updated tags in " + modifiedScenes + " scenes to include tag(s) from their markers.");
+
+    } else if (input.Args.hookContext) {
+        // hook triggered
+        var hookContext = input.Args.hookContext;
+        var opInput = hookContext.input;
+        var primaryMarkerTagID = opInput.primary_tag_id;
+        var otherMarkerTagIDs = opInput.tag_ids;
+        var sceneID = opInput.scene_id;
+
+        // check if missing any of the required fields
+        if (!primaryMarkerTagID || !sceneID) {
+            // just return
+            return ok();
         }
 
-        tagIDs.push(tagID);
+        // get the existing scene tags
+        var sceneTagIDs = getSceneTags(sceneID).map(function (item) { return item.id });
+        var combinedTags = concatAndDeduplicate(sceneTagIDs, [primaryMarkerTagID]);
+        if (ALL_MARKER_TAGS && otherMarkerTagIDs) {
+            combinedTags = concatAndDeduplicate(combinedTags, otherMarkerTagIDs);
+        }
+
+        setSceneTags(sceneID, combinedTags);
+        log.Info("Added marker tag(s) to scene " + sceneID);
     }
-
-    // set the tag on the scene if not present
-    tagIDs.push(primaryTagID);
-
-    setSceneTags(sceneID, tagIDs);
-    log.Info("added primary tag " + primaryTagID + " to scene " + sceneID);
 }
 
 function getSceneTags(sceneID) {
@@ -76,6 +112,70 @@ mutation sceneUpdate($input: SceneUpdateInput!) {\
     };
 
     gql.Do(mutation, variables);
+}
+
+function getScenesWithTagsAndMarkers(per_page, page) {
+    var query = "\
+    query FindScenes($filter: FindFilterType, $scene_filter: SceneFilterType, $scene_ids: [Int!]) {\
+        findScenes(filter: $filter, scene_filter: $scene_filter, scene_ids: $scene_ids) {\
+          count\
+          scenes {\
+            ...MarkersAndTagSceneData\
+            __typename\
+          }\
+            __typename\
+        }\
+      } fragment MarkersAndTagSceneData on Scene {\
+        id\
+        scene_markers {\
+          id\
+          primary_tag {\
+            id\
+            __typename\
+          }\
+          tags {\
+            id\
+            __typename\
+          }\
+          __typename\
+        }\
+        tags {\
+          id\
+          __typename\
+        }\
+        __typename\
+      }";
+
+
+    var variables = {
+        "filter": {
+            "direction": "ASC",
+            "page": page,
+            "per_page": per_page,
+            "q": "",
+            "sort": "created_at"
+        },
+        "scene_filter": {
+            "has_markers": "true"
+        }
+
+    }
+
+    var result = gql.Do(query, variables);
+    var findScenes = result.findScenes;
+    if (findScenes) {
+        return findScenes;
+    }
+
+    return {};
+}
+
+function concatAndDeduplicate(a, b) {
+    var combined = a.concat(b);
+    combined = combined.filter(function (item, pos, self) {
+        return self.indexOf(item) == pos;
+    });
+    return combined;
 }
 
 main();

--- a/plugins/markerTagToScene/markerTagToScene.yml
+++ b/plugins/markerTagToScene/markerTagToScene.yml
@@ -1,14 +1,19 @@
 # example plugin config
 name: Scene Marker Tags to Scene
-description: Adds primary tag of Scene Marker to the Scene on marker create/update.
+description: Adds primary tag or all tags of Scene Marker to the Scene on marker create/update, or when task is run.
 url: https://github.com/stashapp/CommunityScripts
-version: 1.0
+version: 1.1
 exec:
   - markerTagToScene.js
 interface: js
 hooks:
-  - name: Update scene with scene marker tag
-    description: Adds primary tag of Scene Marker to the Scene on marker create/update.
+  - name: Update scene with scene marker tag(s)
+    description: Adds primary tag or all tags of Scene Marker to the Scene on marker create/update.
     triggeredBy: 
       - SceneMarker.Create.Post
       - SceneMarker.Update.Post
+tasks:
+  - name: Update Scenes Tags
+    description: Adds primary tag or all tags of Scene Markers to their Scenes
+    defaultArgs:
+      mode: updateAllScenes


### PR DESCRIPTION
Adding task to markerTagToScene plugin that operates on all markers. Added config options to markerTagToScene plugin to enable copying ALL marker tags to scene instead of only the primary tag.