### PR TITLE
Stash userscript library

### DIFF
--- a/plugins/1. stashUserscriptLibrary/StashUserscriptLibrary.yml
+++ b/plugins/1. stashUserscriptLibrary/StashUserscriptLibrary.yml
@@ -1,0 +1,6 @@
+name: Stash Userscript Library
+description: Exports utility functions and a Stash class that emits events whenever a GQL response is received and whenenever a page navigation change is detected
+version: 1.0
+ui:
+  javascript:
+  - stashUserscriptLibrary.js

--- a/plugins/1. stashUserscriptLibrary/stashUserscriptLibrary.js
+++ b/plugins/1. stashUserscriptLibrary/stashUserscriptLibrary.js
@@ -1,0 +1,990 @@
+const stashListener = new EventTarget();
+
+function concatRegexp(reg, exp) {
+    let flags = reg.flags + exp.flags;
+    flags = Array.from(new Set(flags.split(''))).join();
+    return new RegExp(reg.source + exp.source, flags);
+}
+
+class Logger {
+    constructor(enabled) {
+        this.enabled = enabled;
+    }
+    debug() {
+        if (!this.enabled) return;
+        console.debug(...arguments);
+    }
+}
+
+
+class Stash extends EventTarget {
+    constructor({
+        pageUrlCheckInterval = 1,
+        logging = false
+    } = {}) {
+        super();
+        this.log = new Logger(logging);
+        this._pageUrlCheckInterval = pageUrlCheckInterval;
+        this.fireOnHashChangesToo = true;
+        this.pageURLCheckTimer = setInterval(() => {
+            // Loop every 500ms
+            if (this.lastPathStr !== location.pathname || this.lastQueryStr !== location.search || (this.fireOnHashChangesToo && this.lastHashStr !== location.hash)) {
+                this.lastPathStr = location.pathname;
+                this.lastQueryStr = location.search;
+                this.lastHashStr = location.hash;
+                this.gmMain();
+            }
+        }, this._pageUrlCheckInterval);
+        stashListener.addEventListener('response', (evt) => {
+            if (evt.detail.data?.plugins) {
+                this.getPluginVersion(evt.detail);
+            }
+            this.processRemoteScenes(evt.detail);
+            this.processScene(evt.detail);
+            this.processScenes(evt.detail);
+            this.processStudios(evt.detail);
+            this.processPerformers(evt.detail);
+            this.processApiKey(evt.detail);
+            this.dispatchEvent(new CustomEvent('stash:response', {
+                'detail': evt.detail
+            }));
+        });
+        stashListener.addEventListener('pluginVersion', (evt) => {
+            if (this.pluginVersion !== evt.detail) {
+                this.pluginVersion = evt.detail;
+                this.dispatchEvent(new CustomEvent('stash:pluginVersion', {
+                    'detail': evt.detail
+                }));
+            }
+        });
+        this.version = [0, 0, 0];
+        this.getVersion();
+        this.pluginVersion = null;
+        this.getPlugins().then(plugins => this.getPluginVersion(plugins));
+        this.visiblePluginTasks = ['Userscript Functions'];
+        this.settingsCallbacks = [];
+        this.settingsId = 'userscript-settings';
+        this.remoteScenes = {};
+        this.scenes = {};
+        this.studios = {};
+        this.performers = {};
+        this.userscripts = [];
+    }
+    async getVersion() {
+        const reqData = {
+            "operationName": "",
+            "variables": {},
+            "query": `query version {
+    version {
+        version
+    }
+}
+`
+        };
+        const data = await this.callGQL(reqData);
+        const versionString = data.data.version.version;
+        this.version = versionString.substring(1).split('.').map(o => parseInt(o));
+    }
+    compareVersion(minVersion) {
+        let [currMajor, currMinor, currPatch = 0] = this.version;
+        let [minMajor, minMinor, minPatch = 0] = minVersion.split('.').map(i => parseInt(i));
+        if (currMajor > minMajor) return 1;
+        if (currMajor < minMajor) return -1;
+        if (currMinor > minMinor) return 1;
+        if (currMinor < minMinor) return -1;
+        return 0;
+
+    }
+    comparePluginVersion(minPluginVersion) {
+        if (!this.pluginVersion) return -1;
+        let [currMajor, currMinor, currPatch = 0] = this.pluginVersion.split('.').map(i => parseInt(i));
+        let [minMajor, minMinor, minPatch = 0] = minPluginVersion.split('.').map(i => parseInt(i));
+        if (currMajor > minMajor) return 1;
+        if (currMajor < minMajor) return -1;
+        if (currMinor > minMinor) return 1;
+        if (currMinor < minMinor) return -1;
+        return 0;
+
+    }
+    async runPluginTask(pluginId, taskName, args = []) {
+        const reqData = {
+            "operationName": "RunPluginTask",
+            "variables": {
+                "plugin_id": pluginId,
+                "task_name": taskName,
+                "args": args
+            },
+            "query": "mutation RunPluginTask($plugin_id: ID!, $task_name: String!, $args: [PluginArgInput!]) {\n  runPluginTask(plugin_id: $plugin_id, task_name: $task_name, args: $args)\n}\n"
+        };
+        return this.callGQL(reqData);
+    }
+    async callGQL(reqData) {
+        const options = {
+            method: 'POST',
+            body: JSON.stringify(reqData),
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        }
+
+        try {
+            const res = await window.fetch('/graphql', options);
+            this.log.debug(res);
+            return res.json();
+        } catch (err) {
+            console.error(err);
+        }
+    }
+    async getFreeOnesStats(link) {
+        try {
+            const doc = await fetch(link)
+            .then(function(response) {
+                // When the page is loaded convert it to text
+                return response.text()
+            })
+            .then(function(html) {
+                // Initialize the DOM parser
+                var parser = new DOMParser();
+
+                // Parse the text
+                var doc = parser.parseFromString(html, "text/html");
+
+                // You can now even select part of that html as you would in the regular DOM
+                // Example:
+                // var docArticle = doc.querySelector('article').innerHTML;
+
+                console.log(doc);
+                return doc
+            })
+            .catch(function(err) {
+                console.log('Failed to fetch page: ', err);
+            });
+
+            var data = new Object();
+            data.rank = doc.querySelector('rank-chart-button');
+            console.log(data.rank);
+            data.views = doc.querySelector('.d-none.d-m-flex.flex-column.align-items-center.global-header > div.font-weight-bold').textContent;
+            data.votes = '0'
+            return JSON.stringify(data);
+        } catch (err) {
+            console.error(err);
+        }
+    }
+    async getPlugins() {
+        const reqData = {
+            "operationName": "Plugins",
+            "variables": {},
+            "query": `query Plugins {
+              plugins {
+                id
+                name
+                description
+                url
+                version
+                tasks {
+                  name
+                  description
+                  __typename
+                }
+                hooks {
+                  name
+                  description
+                  hooks
+                }
+              }
+            }
+            `
+        };
+        return this.callGQL(reqData);
+    }
+    async getPluginVersion(plugins) {
+        let version = null;
+        for (const plugin of plugins?.data?.plugins || []) {
+            if (plugin.id === 'userscript_functions') {
+                version = plugin.version;
+            }
+        }
+        stashListener.dispatchEvent(new CustomEvent('pluginVersion', {
+            'detail': version
+        }));
+    }
+    async getStashBoxes() {
+        const reqData = {
+            "operationName": "Configuration",
+            "variables": {},
+            "query": `query Configuration {
+                        configuration {
+                          general {
+                            stashBoxes {
+                              endpoint
+                              api_key
+                              name
+                            }
+                          }
+                        }
+                      }`
+        };
+        return this.callGQL(reqData);
+    }
+    async getApiKey() {
+        const reqData = {
+            "operationName": "Configuration",
+            "variables": {},
+            "query": `query Configuration {
+                        configuration {
+                          general {
+                            apiKey
+                          }
+                        }
+                      }`
+        };
+        return this.callGQL(reqData);
+    }
+    matchUrl(location, fragment) {
+        const regexp = concatRegexp(new RegExp(location.origin), fragment);
+        this.log.debug(regexp, location.href.match(regexp));
+        return location.href.match(regexp) != null;
+    }
+    createSettings() {
+        waitForElementId('configuration-tabs-tabpane-system', async (elementId, el) => {
+            let section;
+            if (!document.getElementById(this.settingsId)) {
+                section = document.createElement("div");
+                section.setAttribute('id', this.settingsId);
+                section.classList.add('setting-section');
+                section.innerHTML = `<h1>Userscript Settings</h1>`;
+                el.appendChild(section);
+
+                const expectedApiKey = (await this.getApiKey())?.data?.configuration?.general?.apiKey || '';
+                const expectedUrl = window.location.origin;
+
+                const serverUrlInput = await this.createSystemSettingTextbox(section, 'userscript-section-server-url', 'userscript-server-url', 'Stash Server URL', '', 'Server URL…', true);
+                serverUrlInput.addEventListener('change', () => {
+                    const value = serverUrlInput.value || '';
+                    if (value) {
+                        this.updateConfigValueTask('STASH', 'url', value);
+                        alert(`Userscripts plugin server URL set to ${value}`);
+                    } else {
+                        this.getConfigValueTask('STASH', 'url').then(value => {
+                            serverUrlInput.value = value;
+                        });
+                    }
+                });
+                serverUrlInput.disabled = true;
+                serverUrlInput.value = expectedUrl;
+                this.getConfigValueTask('STASH', 'url').then(value => {
+                    if (value !== expectedUrl) {
+                        return this.updateConfigValueTask('STASH', 'url', expectedUrl);
+                    }
+                });
+
+                const apiKeyInput = await this.createSystemSettingTextbox(section, 'userscript-section-server-apikey', 'userscript-server-apikey', 'Stash API Key', '', 'API Key…', true);
+                apiKeyInput.addEventListener('change', () => {
+                    const value = apiKeyInput.value || '';
+                    this.updateConfigValueTask('STASH', 'api_key', value);
+                    if (value) {
+                        alert(`Userscripts plugin server api key set to ${value}`);
+                    } else {
+                        alert(`Userscripts plugin server api key value cleared`);
+                    }
+                });
+                apiKeyInput.disabled = true;
+                apiKeyInput.value = expectedApiKey;
+                this.getConfigValueTask('STASH', 'api_key').then(value => {
+                    if (value !== expectedApiKey) {
+                        return this.updateConfigValueTask('STASH', 'api_key', expectedApiKey);
+                    }
+                });
+            } else {
+                section = document.getElementById(this.settingsId);
+            }
+
+            for (const callback of this.settingsCallbacks) {
+                callback(this.settingsId, section);
+            }
+
+            if (this.pluginVersion) {
+                this.dispatchEvent(new CustomEvent('stash:pluginVersion', {
+                    'detail': this.pluginVersion
+                }));
+            }
+
+        });
+    }
+    addSystemSetting(callback) {
+        const section = document.getElementById(this.settingsId);
+        if (section) {
+            callback(this.settingsId, section);
+        }
+        this.settingsCallbacks.push(callback);
+    }
+    async createSystemSettingCheckbox(containerEl, settingsId, inputId, settingsHeader, settingsSubheader) {
+        const section = document.createElement("div");
+        section.setAttribute('id', settingsId);
+        section.classList.add('card');
+        section.style.display = 'none';
+        section.innerHTML = `<div class="setting">
+        <div>
+        <h3>${settingsHeader}</h3>
+        <div class="sub-heading">${settingsSubheader}</div>
+        </div>
+        <div>
+        <div class="custom-control custom-switch">
+        <input type="checkbox" id="${inputId}" class="custom-control-input">
+        <label title="" for="${inputId}" class="custom-control-label"></label>
+        </div>
+        </div>
+        </div>`;
+        containerEl.appendChild(section);
+        return document.getElementById(inputId);
+    }
+    async createSystemSettingTextbox(containerEl, settingsId, inputId, settingsHeader, settingsSubheader, placeholder, visible) {
+        const section = document.createElement("div");
+        section.setAttribute('id', settingsId);
+        section.classList.add('card');
+        section.style.display = visible ? 'flex' : 'none';
+        section.innerHTML = `<div class="setting">
+        <div>
+        <h3>${settingsHeader}</h3>
+        <div class="sub-heading">${settingsSubheader}</div>
+        </div>
+        <div>
+        <div class="flex-grow-1 query-text-field-group">
+        <input id="${inputId}" class="bg-secondary text-white border-secondary form-control" placeholder="${placeholder}">
+        </div>
+        </div>
+        </div>`;
+        containerEl.appendChild(section);
+        return document.getElementById(inputId);
+    }
+    get serverUrl() {
+        return window.location.origin;
+    }
+    gmMain() {
+        const location = window.location;
+        this.log.debug(URL, window.location);
+
+        // marker wall
+        if (this.matchUrl(location, /\/scenes\/markers/)) {
+            this.log.debug('[Navigation] Wall-Markers Page');
+            this.dispatchEvent(new Event('page:markers'));
+        }
+        // scene page
+        else if (this.matchUrl(location, /\/scenes\/\d+/)) {
+            this.log.debug('[Navigation] Scene Page');
+            this.dispatchEvent(new Event('page:scene'));
+        }
+        // scenes wall
+        else if (this.matchUrl(location, /\/scenes\?/)) {
+            this.processTagger();
+            this.dispatchEvent(new Event('page:scenes'));
+        }
+
+        // images wall
+        if (this.matchUrl(location, /\/images\?/)) {
+            this.log.debug('[Navigation] Wall-Images Page');
+            this.dispatchEvent(new Event('page:images'));
+        }
+        // image page
+        if (this.matchUrl(location, /\/images\/\d+/)) {
+            this.log.debug('[Navigation] Image Page');
+            this.dispatchEvent(new Event('page:image'));
+        }
+
+        // movie scenes page
+        else if (this.matchUrl(location, /\/movies\/\d+\?/)) {
+            this.log.debug('[Navigation] Movie Page - Scenes');
+            this.processTagger();
+            this.dispatchEvent(new Event('page:movie:scenes'));
+        }
+        // movie page
+        else if (this.matchUrl(location, /\/movies\/\d+/)) {
+            this.log.debug('[Navigation] Movie Page');
+            this.dispatchEvent(new Event('page:movie'));
+        }
+        // movies wall
+        else if (this.matchUrl(location, /\/movies\?/)) {
+            this.log.debug('[Navigation] Wall-Movies Page');
+            this.dispatchEvent(new Event('page:movies'));
+        }
+
+        // galleries wall
+        if (this.matchUrl(location, /\/galleries\?/)) {
+            this.log.debug('[Navigation] Wall-Galleries Page');
+            this.dispatchEvent(new Event('page:galleries'));
+        }
+        // gallery page
+        if (this.matchUrl(location, /\/galleries\/\d+/)) {
+            this.log.debug('[Navigation] Gallery Page');
+            this.dispatchEvent(new Event('page:gallery'));
+        }
+
+        // performer scenes page
+        if (this.matchUrl(location, /\/performers\/\d+\?/)) {
+            this.log.debug('[Navigation] Performer Page - Scenes');
+            this.processTagger();
+            this.dispatchEvent(new Event('page:performer:scenes'));
+        }
+        // performer appearswith page
+        if (this.matchUrl(location, /\/performers\/\d+\/appearswith/)) {
+            this.log.debug('[Navigation] Performer Page - Appears With');
+            this.processTagger();
+            this.dispatchEvent(new Event('page:performer:performers'));
+        }
+        // performer galleries page
+        else if (this.matchUrl(location, /\/performers\/\d+\/galleries/)) {
+            this.log.debug('[Navigation] Performer Page - Galleries');
+            this.dispatchEvent(new Event('page:performer:galleries'));
+        }
+        // performer movies page
+        else if (this.matchUrl(location, /\/performers\/\d+\/movies/)) {
+            this.log.debug('[Navigation] Performer Page - Movies');
+            this.dispatchEvent(new Event('page:performer:movies'));
+        }
+        // performer page
+        else if (this.matchUrl(location, /\/performers\//)) {
+            this.log.debug('[Navigation] Performers Page');
+            this.dispatchEvent(new Event('page:performer'));
+            this.dispatchEvent(new Event('page:performer:details'));
+
+            waitForElementClass('performer-tabs', (className, targetNode) => {
+                const observerOptions = {
+                    childList: true
+                }
+                const observer = new MutationObserver(mutations => {
+                    let isPerformerEdit = false;
+                    mutations.forEach(mutation => {
+                        mutation.addedNodes.forEach(node => {
+                            if (node.id === 'performer-edit') {
+                                isPerformerEdit = true;
+                            }
+                        });
+                    });
+                    if (isPerformerEdit) {
+                        this.dispatchEvent(new Event('page:performer:edit'));
+                    } else {
+                        this.dispatchEvent(new Event('page:performer:details'));
+                    }
+                });
+                observer.observe(targetNode[0], observerOptions);
+            });
+        }
+        // performers wall
+        else if (this.matchUrl(location, /\/performers\?/)) {
+            this.log.debug('[Navigation] Wall-Performers Page');
+            this.dispatchEvent(new Event('page:performers'));
+        }
+
+        // studio galleries page
+        if (this.matchUrl(location, /\/studios\/\d+\/galleries/)) {
+            this.log.debug('[Navigation] Studio Page - Galleries');
+            this.dispatchEvent(new Event('page:studio:galleries'));
+        }
+        // studio images page
+        else if (this.matchUrl(location, /\/studios\/\d+\/images/)) {
+            this.log.debug('[Navigation] Studio Page - Images');
+            this.dispatchEvent(new Event('page:studio:images'));
+        }
+        // studio performers page
+        else if (this.matchUrl(location, /\/studios\/\d+\/performers/)) {
+            this.log.debug('[Navigation] Studio Page - Performers');
+            this.dispatchEvent(new Event('page:studio:performers'));
+        }
+        // studio movies page
+        else if (this.matchUrl(location, /\/studios\/\d+\/movies/)) {
+            this.log.debug('[Navigation] Studio Page - Movies');
+            this.dispatchEvent(new Event('page:studio:movies'));
+        }
+        // studio childstudios page
+        else if (this.matchUrl(location, /\/studios\/\d+\/childstudios/)) {
+            this.log.debug('[Navigation] Studio Page - Child Studios');
+            this.dispatchEvent(new Event('page:studio:childstudios'));
+        }
+        // studio scenes page
+        else if (this.matchUrl(location, /\/studios\/\d+\?/)) {
+            this.log.debug('[Navigation] Studio Page - Scenes');
+            this.processTagger();
+            this.dispatchEvent(new Event('page:studio:scenes'));
+        }
+        // studio page
+        else if (this.matchUrl(location, /\/studios\/\d+/)) {
+            this.log.debug('[Navigation] Studio Page');
+            this.dispatchEvent(new Event('page:studio'));
+        }
+        // studios wall
+        else if (this.matchUrl(location, /\/studios\?/)) {
+            this.log.debug('[Navigation] Wall-Studios Page');
+            this.dispatchEvent(new Event('page:studios'));
+        }
+
+        // tag galleries page
+        if (this.matchUrl(location, /\/tags\/\d+\/galleries/)) {
+            this.log.debug('[Navigation] Tag Page - Galleries');
+            this.dispatchEvent(new Event('page:tag:galleries'));
+        }
+        // tag images page
+        else if (this.matchUrl(location, /\/tags\/\d+\/images/)) {
+            this.log.debug('[Navigation] Tag Page - Images');
+            this.dispatchEvent(new Event('page:tag:images'));
+        }
+        // tag markers page
+        else if (this.matchUrl(location, /\/tags\/\d+\/markers/)) {
+            this.log.debug('[Navigation] Tag Page - Markers');
+            this.dispatchEvent(new Event('page:tag:markers'));
+        }
+        // tag performers page
+        else if (this.matchUrl(location, /\/tags\/\d+\/performers/)) {
+            this.log.debug('[Navigation] Tag Page - Performers');
+            this.dispatchEvent(new Event('page:tag:performers'));
+        }
+        // tag scenes page
+        else if (this.matchUrl(location, /\/tags\/\d+\?/)) {
+            this.log.debug('[Navigation] Tag Page - Scenes');
+            this.processTagger();
+            this.dispatchEvent(new Event('page:tag:scenes'));
+        }
+        // tag page
+        else if (this.matchUrl(location, /\/tags\/\d+/)) {
+            this.log.debug('[Navigation] Tag Page');
+            this.dispatchEvent(new Event('page:tag'));
+        }
+        // tags any page
+        if (this.matchUrl(location, /\/tags\/\d+/)) {
+            this.log.debug('[Navigation] Tag Page - Any');
+            this.dispatchEvent(new Event('page:tag:any'));
+        }
+        // tags wall
+        else if (this.matchUrl(location, /\/tags\?/)) {
+            this.log.debug('[Navigation] Wall-Tags Page');
+            this.dispatchEvent(new Event('page:tags'));
+        }
+
+        // settings page tasks tab
+        if (this.matchUrl(location, /\/settings\?tab=tasks/)) {
+            this.log.debug('[Navigation] Settings Page Tasks Tab');
+            this.dispatchEvent(new Event('page:settings:tasks'));
+            this.hidePluginTasks();
+        }
+        // settings page system tab
+        else if (this.matchUrl(location, /\/settings\?tab=system/)) {
+            this.log.debug('[Navigation] Settings Page System Tab');
+            this.createSettings();
+            this.dispatchEvent(new Event('page:settings:system'));
+        }
+        // settings page (defaults to tasks tab)
+        else if (this.matchUrl(location, /\/settings/)) {
+            this.log.debug('[Navigation] Settings Page Tasks Tab');
+            this.dispatchEvent(new Event('page:settings:tasks'));
+            this.hidePluginTasks();
+        }
+
+        // stats page
+        if (this.matchUrl(location, /\/stats/)) {
+            this.log.debug('[Navigation] Stats Page');
+            this.dispatchEvent(new Event('page:stats'));
+        }
+    }
+    hidePluginTasks() {
+        // hide userscript functions plugin tasks
+        waitForElementByXpath("//div[@id='tasks-panel']//h3[text()='Userscript Functions']/ancestor::div[contains(@class, 'setting-group')]", (elementId, el) => {
+            const tasks = el.querySelectorAll('.setting');
+            for (const task of tasks) {
+                const taskName = task.querySelector('h3').innerText;
+                task.classList.add(this.visiblePluginTasks.indexOf(taskName) === -1 ? 'd-none' : 'd-flex');
+                this.dispatchEvent(new CustomEvent('stash:plugin:task', {
+                    'detail': {
+                        taskName,
+                        task
+                    }
+                }));
+            }
+        });
+    }
+    async updateConfigValueTask(sectionKey, propName, value) {
+        return this.runPluginTask("userscript_functions", "Update Config Value", [{
+            "key": "section_key",
+            "value": {
+                "str": sectionKey
+            }
+        }, {
+            "key": "prop_name",
+            "value": {
+                "str": propName
+            }
+        }, {
+            "key": "value",
+            "value": {
+                "str": value
+            }
+        }]);
+    }
+    async getConfigValueTask(sectionKey, propName) {
+        await this.runPluginTask("userscript_functions", "Get Config Value", [{
+            "key": "section_key",
+            "value": {
+                "str": sectionKey
+            }
+        }, {
+            "key": "prop_name",
+            "value": {
+                "str": propName
+            }
+        }]);
+
+        // poll logs until plugin task output appears
+        const prefix = `[Plugin / Userscript Functions] get_config_value: [${sectionKey}][${propName}] =`;
+        return this.pollLogsForMessage(prefix);
+    }
+    async pollLogsForMessage(prefix) {
+        const reqTime = Date.now();
+        const reqData = {
+            "variables": {},
+            "query": `query Logs {
+                        logs {
+                            time
+                            level
+                            message
+                        }
+                    }`
+        };
+        await new Promise(r => setTimeout(r, 500));
+        let retries = 0;
+        while (true) {
+            const delay = 2 ** retries * 100;
+            await new Promise(r => setTimeout(r, delay));
+            retries++;
+
+            const logs = await this.callGQL(reqData);
+            for (const log of logs.data.logs) {
+                const logTime = Date.parse(log.time);
+                if (logTime > reqTime && log.message.startsWith(prefix)) {
+                    return log.message.replace(prefix, '').trim();
+                }
+            }
+
+            if (retries >= 5) {
+                throw `Poll logs failed for message: ${prefix}`;
+            }
+        }
+    }
+    processTagger() {
+        waitForElementByXpath("//button[text()='Scrape All']", (xpath, el) => {
+            this.dispatchEvent(new CustomEvent('tagger', {
+                'detail': el
+            }));
+
+            const searchItemContainer = document.querySelector('.tagger-container').lastChild;
+
+            const observer = new MutationObserver(mutations => {
+                mutations.forEach(mutation => {
+                    mutation.addedNodes.forEach(node => {
+                        if (node?.classList?.contains('entity-name') && node.innerText.startsWith('Performer:')) {
+                            this.dispatchEvent(new CustomEvent('tagger:mutation:add:remoteperformer', {
+                                'detail': {
+                                    node,
+                                    mutation
+                                }
+                            }));
+                        } else if (node?.classList?.contains('entity-name') && node.innerText.startsWith('Studio:')) {
+                            this.dispatchEvent(new CustomEvent('tagger:mutation:add:remotestudio', {
+                                'detail': {
+                                    node,
+                                    mutation
+                                }
+                            }));
+                        } else if (node.tagName === 'SPAN' && node.innerText.startsWith('Matched:')) {
+                            this.dispatchEvent(new CustomEvent('tagger:mutation:add:local', {
+                                'detail': {
+                                    node,
+                                    mutation
+                                }
+                            }));
+                        } else if (node.tagName === 'UL') {
+                            this.dispatchEvent(new CustomEvent('tagger:mutation:add:container', {
+                                'detail': {
+                                    node,
+                                    mutation
+                                }
+                            }));
+                        } else if (node?.classList?.contains('col-lg-6')) {
+                            this.dispatchEvent(new CustomEvent('tagger:mutation:add:subcontainer', {
+                                'detail': {
+                                    node,
+                                    mutation
+                                }
+                            }));
+                        } else if (node.tagName === 'H5') { // scene date
+                            this.dispatchEvent(new CustomEvent('tagger:mutation:add:date', {
+                                'detail': {
+                                    node,
+                                    mutation
+                                }
+                            }));
+                        } else if (node.tagName === 'DIV' && node?.classList?.contains('d-flex') && node?.classList?.contains('flex-column')) { // scene stashid, url, details
+                            this.dispatchEvent(new CustomEvent('tagger:mutation:add:detailscontainer', {
+                                'detail': {
+                                    node,
+                                    mutation
+                                }
+                            }));
+                        } else {
+                            this.dispatchEvent(new CustomEvent('tagger:mutation:add:other', {
+                                'detail': {
+                                    node,
+                                    mutation
+                                }
+                            }));
+                        }
+                    });
+                });
+                this.dispatchEvent(new CustomEvent('tagger:mutations:searchitems', {
+                    'detail': mutations
+                }));
+            });
+            observer.observe(searchItemContainer, {
+                childList: true,
+                subtree: true
+            });
+
+            const taggerContainerHeader = document.querySelector('.tagger-container-header');
+            const taggerContainerHeaderObserver = new MutationObserver(mutations => {
+                this.dispatchEvent(new CustomEvent('tagger:mutations:header', {
+                    'detail': mutations
+                }));
+            });
+            taggerContainerHeaderObserver.observe(taggerContainerHeader, {
+                childList: true,
+                subtree: true
+            });
+
+            for (const searchItem of document.querySelectorAll('.search-item')) {
+                this.dispatchEvent(new CustomEvent('tagger:searchitem', {
+                    'detail': searchItem
+                }));
+            }
+
+            if (!document.getElementById('progress-bar')) {
+                const progressBar = createElementFromHTML(`<div id="progress-bar" class="progress"><div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div></div>`);
+                progressBar.classList.add('progress');
+                progressBar.style.display = 'none';
+                taggerContainerHeader.appendChild(progressBar);
+            }
+        });
+        waitForElementByXpath("//div[@class='tagger-container-header']/div/div[@class='row']/h4[text()='Configuration']", (xpath, el) => {
+            this.dispatchEvent(new CustomEvent('tagger:configuration', {
+                'detail': el
+            }));
+        });
+    }
+    setProgress(value) {
+        const progressBar = document.getElementById('progress-bar');
+        if (progressBar) {
+            progressBar.firstChild.style.width = value + '%';
+            progressBar.style.display = (value <= 0 || value > 100) ? 'none' : 'flex';
+        }
+    }
+    processRemoteScenes(data) {
+        if (data.data?.scrapeMultiScenes) {
+            for (const matchResults of data.data.scrapeMultiScenes) {
+                for (const scene of matchResults) {
+                    this.remoteScenes[scene.remote_site_id] = scene;
+                }
+            }
+        } else if (data.data?.scrapeSingleScene) {
+            for (const scene of data.data.scrapeSingleScene) {
+                this.remoteScenes[scene.remote_site_id] = scene;
+            }
+        }
+    }
+    processScene(data) {
+        if (data.data.findScene) {
+            this.scenes[data.data.findScene.id] = data.data.findScene;
+        }
+    }
+    processScenes(data) {
+        if (data.data.findScenes?.scenes) {
+            for (const scene of data.data.findScenes.scenes) {
+                this.scenes[scene.id] = scene;
+            }
+        }
+    }
+    processStudios(data) {
+        if (data.data.findStudios?.studios) {
+            for (const studio of data.data.findStudios.studios) {
+                this.studios[studio.id] = studio;
+            }
+        }
+    }
+    processPerformers(data) {
+        if (data.data.findPerformers?.performers) {
+            for (const performer of data.data.findPerformers.performers) {
+                this.performers[performer.id] = performer;
+            }
+        }
+    }
+    processApiKey(data) {
+        if (data.data.generateAPIKey != null && this.pluginVersion) {
+            this.updateConfigValueTask('STASH', 'api_key', data.data.generateAPIKey);
+        }
+    }
+    parseSearchItem(searchItem) {
+        const urlNode = searchItem.querySelector('a.scene-link');
+        const url = new URL(urlNode.href);
+        const id = url.pathname.replace('/scenes/', '');
+        const data = this.scenes[id];
+        const nameNode = searchItem.querySelector('a.scene-link > div.TruncatedText');
+        const name = nameNode.innerText;
+        const queryInput = searchItem.querySelector('input.text-input');
+        const performerNodes = searchItem.querySelectorAll('.performer-tag-container');
+
+        return {
+            urlNode,
+            url,
+            id,
+            data,
+            nameNode,
+            name,
+            queryInput,
+            performerNodes
+        }
+    }
+    parseSearchResultItem(searchResultItem) {
+        const remoteUrlNode = searchResultItem.querySelector('.scene-details .optional-field .optional-field-content a');
+        const remoteId = remoteUrlNode?.href.split('/').pop();
+        const remoteUrl = remoteUrlNode?.href ? new URL(remoteUrlNode.href) : null;
+        const remoteData = this.remoteScenes[remoteId];
+
+        const sceneDetailNodes = searchResultItem.querySelectorAll('.scene-details .optional-field .optional-field-content');
+        let urlNode = null;
+        let detailsNode = null;
+        for (const sceneDetailNode of sceneDetailNodes) {
+            if (remoteData?.url === sceneDetailNode.innerText) {
+                urlNode = sceneDetailNode;
+            } else if (remoteData?.details === sceneDetailNode.textContent) {
+                detailsNode = sceneDetailNode;
+            }
+        }
+
+        const imageNode = searchResultItem.querySelector('.scene-image-container .optional-field .optional-field-content');
+
+        const metadataNode = searchResultItem.querySelector('.scene-metadata');
+        const titleNode = metadataNode.querySelector('h4 .optional-field .optional-field-content');
+        const dateNode = metadataNode.querySelector('h5 .optional-field .optional-field-content');
+
+        const entityNodes = searchResultItem.querySelectorAll('.entity-name');
+        let studioNode = null;
+        const performerNodes = [];
+        for (const entityNode of entityNodes) {
+            if (entityNode.innerText.startsWith('Studio:')) {
+                studioNode = entityNode;
+            } else if (entityNode.innerText.startsWith('Performer:')) {
+                performerNodes.push(entityNode);
+            }
+        }
+
+        const matchNodes = searchResultItem.querySelectorAll('div.col-lg-6 div.mt-2 div.row.no-gutters.my-2 span.ml-auto');
+        const matches = []
+        for (const matchNode of matchNodes) {
+            let matchType = null;
+            const entityNode = matchNode.parentElement.querySelector('.entity-name');
+
+            const matchName = matchNode.querySelector('.optional-field-content b').innerText;
+            const remoteName = entityNode.querySelector('b').innerText;
+
+            let data;
+            if (entityNode.innerText.startsWith('Performer:')) {
+                matchType = 'performer';
+                if (remoteData) {
+                    data = remoteData.performers.find(performer => performer.name === remoteName);
+                }
+            } else if (entityNode.innerText.startsWith('Studio:')) {
+                matchType = 'studio';
+                if (remoteData) {
+                    data = remoteData.studio
+                }
+            }
+
+            matches.push({
+                matchType,
+                matchNode,
+                entityNode,
+                matchName,
+                remoteName,
+                data
+            });
+        }
+
+        return {
+            remoteUrlNode,
+            remoteId,
+            remoteUrl,
+            remoteData,
+            urlNode,
+            detailsNode,
+            imageNode,
+            titleNode,
+            dateNode,
+            studioNode,
+            performerNodes,
+            matches
+        }
+    }
+}
+
+stash = new Stash();
+
+function waitForElementClass(elementId, callBack, time) {
+    time = (typeof time !== 'undefined') ? time : 100;
+    window.setTimeout(() => {
+        const element = document.getElementsByClassName(elementId);
+        if (element.length > 0) {
+            callBack(elementId, element);
+        } else {
+            waitForElementClass(elementId, callBack);
+        }
+    }, time);
+}
+
+function waitForElementId(elementId, callBack, time) {
+    time = (typeof time !== 'undefined') ? time : 100;
+    window.setTimeout(() => {
+        const element = document.getElementById(elementId);
+        if (element != null) {
+            callBack(elementId, element);
+        } else {
+            waitForElementId(elementId, callBack);
+        }
+    }, time);
+}
+
+function waitForElementByXpath(xpath, callBack, time) {
+    time = (typeof time !== 'undefined') ? time : 100;
+    window.setTimeout(() => {
+        const element = getElementByXpath(xpath);
+        if (element) {
+            callBack(xpath, element);
+        } else {
+            waitForElementByXpath(xpath, callBack);
+        }
+    }, time);
+}
+
+function getElementByXpath(xpath, contextNode) {
+    return document.evaluate(xpath, contextNode || document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+}
+
+function createStatElement(container, title, heading) {
+    const statEl = document.createElement('div');
+    statEl.classList.add('stats-element');
+    container.appendChild(statEl);
+
+    const statTitle = document.createElement('p');
+    statTitle.classList.add('title');
+    statTitle.innerText = title;
+    statEl.appendChild(statTitle);
+
+    const statHeading = document.createElement('p');
+    statHeading.classList.add('heading');
+    statHeading.innerText = heading;
+    statEl.appendChild(statHeading);
+}

--- a/plugins/2. stats/stats.js
+++ b/plugins/2. stats/stats.js
@@ -1,0 +1,134 @@
+function createStatElement(container, title, heading) {
+    const statEl = document.createElement('div');
+    statEl.classList.add('stats-element');
+    container.appendChild(statEl);
+
+    const statTitle = document.createElement('p');
+    statTitle.classList.add('title');
+    statTitle.innerText = title;
+    statEl.appendChild(statTitle);
+
+    const statHeading = document.createElement('p');
+    statHeading.classList.add('heading');
+    statHeading.innerText = heading;
+    statEl.appendChild(statHeading);
+}
+
+async function createSceneStashIDPct(row) {
+    const reqData = {
+        "variables": {
+            "scene_filter": {
+                "stash_id": {
+                    "value": "",
+                    "modifier": "NOT_NULL"
+                }
+            }
+        },
+        "query": "query FindScenes($filter: FindFilterType, $scene_filter: SceneFilterType, $scene_ids: [Int!]) {\n  findScenes(filter: $filter, scene_filter: $scene_filter, scene_ids: $scene_ids) {\n    count\n  }\n}"
+    };
+    const stashIdCount = (await stash.callGQL(reqData)).data.findScenes.count;
+
+    const reqData2 = {
+        "variables": {
+            "scene_filter": {}
+        },
+        "query": "query FindScenes($filter: FindFilterType, $scene_filter: SceneFilterType, $scene_ids: [Int!]) {\n  findScenes(filter: $filter, scene_filter: $scene_filter, scene_ids: $scene_ids) {\n    count\n  }\n}"
+    };
+    const totalCount = (await stash.callGQL(reqData2)).data.findScenes.count;
+
+    createStatElement(row, (stashIdCount / totalCount * 100).toFixed(2) + '%', 'Scene StashIDs');
+}
+
+async function createPerformerStashIDPct(row) {
+    const reqData = {
+        "variables": {
+            "performer_filter": {
+                "stash_id": {
+                    "value": "",
+                    "modifier": "NOT_NULL"
+                }
+            }
+        },
+        "query": "query FindPerformers($filter: FindFilterType, $performer_filter: PerformerFilterType) {\n  findPerformers(filter: $filter, performer_filter: $performer_filter) {\n    count\n  }\n}"
+    };
+    const stashIdCount = (await stash.callGQL(reqData)).data.findPerformers.count;
+
+    const reqData2 = {
+        "variables": {
+            "performer_filter": {}
+        },
+        "query": "query FindPerformers($filter: FindFilterType, $performer_filter: PerformerFilterType) {\n  findPerformers(filter: $filter, performer_filter: $performer_filter) {\n    count\n  }\n}"
+    };
+    const totalCount = (await stash.callGQL(reqData2)).data.findPerformers.count;
+
+    createStatElement(row, (stashIdCount / totalCount * 100).toFixed(2) + '%', 'Performer StashIDs');
+}
+
+async function createStudioStashIDPct(row) {
+    const reqData = {
+        "variables": {
+            "studio_filter": {
+                "stash_id": {
+                    "value": "",
+                    "modifier": "NOT_NULL"
+                }
+            }
+        },
+        "query": "query FindStudios($filter: FindFilterType, $studio_filter: StudioFilterType) {\n  findStudios(filter: $filter, studio_filter: $studio_filter) {\n    count\n  }\n}"
+    };
+    const stashIdCount = (await stash.callGQL(reqData)).data.findStudios.count;
+
+    const reqData2 = {
+        "variables": {
+            "scene_filter": {}
+        },
+        "query": "query FindStudios($filter: FindFilterType, $studio_filter: StudioFilterType) {\n  findStudios(filter: $filter, studio_filter: $studio_filter) {\n    count\n  }\n}"
+    };
+    const totalCount = (await stash.callGQL(reqData2)).data.findStudios.count;
+
+    createStatElement(row, (stashIdCount / totalCount * 100).toFixed(2) + '%', 'Studio StashIDs');
+}
+
+async function createPerformerFavorites(row) {
+    const reqData = {
+        "variables": {
+            "performer_filter": {
+                "filter_favorites": true
+            }
+        },
+        "query": "query FindPerformers($filter: FindFilterType, $performer_filter: PerformerFilterType) {\n  findPerformers(filter: $filter, performer_filter: $performer_filter) {\n    count\n  }\n}"
+    };
+    const perfCount = (await stash.callGQL(reqData)).data.findPerformers.count;
+
+    createStatElement(row, perfCount, 'Favorite Performers');
+}
+
+async function createMarkersStat(row) {
+    const reqData = {
+        "variables": {
+            "scene_marker_filter": {}
+        },
+        "query": "query FindSceneMarkers($filter: FindFilterType, $scene_marker_filter: SceneMarkerFilterType) {\n  findSceneMarkers(filter: $filter, scene_marker_filter: $scene_marker_filter) {\n    count\n  }\n}"
+    };
+    const totalCount = (await stash.callGQL(reqData)).data.findSceneMarkers.count;
+
+    createStatElement(row, totalCount, 'Markers');
+}
+
+stash.addEventListener('page:stats', function() {
+    waitForElementByXpath("//div[contains(@class, 'container-fluid')]/div[@class='mt-5']", function(xpath, el) {
+        if (!document.getElementById('custom-stats-row')) {
+            const changelog = el.querySelector('div.changelog');
+            const row = document.createElement('div');
+            row.setAttribute('id', 'custom-stats-row');
+            row.classList.add('col', 'col-sm-8', 'm-sm-auto', 'row', 'stats');
+            el.insertBefore(row, changelog);
+
+            createSceneStashIDPct(row);
+            createStudioStashIDPct(row);
+            createPerformerStashIDPct(row);
+            createPerformerFavorites(row);
+            createMarkersStat(row);
+        }
+    });
+});

--- a/plugins/2. stats/stats.js
+++ b/plugins/2. stats/stats.js
@@ -1,134 +1,136 @@
-function createStatElement(container, title, heading) {
-    const statEl = document.createElement('div');
-    statEl.classList.add('stats-element');
-    container.appendChild(statEl);
+(function() {
+    function createStatElement(container, title, heading) {
+        const statEl = document.createElement('div');
+        statEl.classList.add('stats-element');
+        container.appendChild(statEl);
 
-    const statTitle = document.createElement('p');
-    statTitle.classList.add('title');
-    statTitle.innerText = title;
-    statEl.appendChild(statTitle);
+        const statTitle = document.createElement('p');
+        statTitle.classList.add('title');
+        statTitle.innerText = title;
+        statEl.appendChild(statTitle);
 
-    const statHeading = document.createElement('p');
-    statHeading.classList.add('heading');
-    statHeading.innerText = heading;
-    statEl.appendChild(statHeading);
-}
+        const statHeading = document.createElement('p');
+        statHeading.classList.add('heading');
+        statHeading.innerText = heading;
+        statEl.appendChild(statHeading);
+    }
 
-async function createSceneStashIDPct(row) {
-    const reqData = {
-        "variables": {
-            "scene_filter": {
-                "stash_id": {
-                    "value": "",
-                    "modifier": "NOT_NULL"
+    async function createSceneStashIDPct(row) {
+        const reqData = {
+            "variables": {
+                "scene_filter": {
+                    "stash_id": {
+                        "value": "",
+                        "modifier": "NOT_NULL"
+                    }
                 }
-            }
-        },
-        "query": "query FindScenes($filter: FindFilterType, $scene_filter: SceneFilterType, $scene_ids: [Int!]) {\n  findScenes(filter: $filter, scene_filter: $scene_filter, scene_ids: $scene_ids) {\n    count\n  }\n}"
-    };
-    const stashIdCount = (await stash.callGQL(reqData)).data.findScenes.count;
+            },
+            "query": "query FindScenes($filter: FindFilterType, $scene_filter: SceneFilterType, $scene_ids: [Int!]) {\n  findScenes(filter: $filter, scene_filter: $scene_filter, scene_ids: $scene_ids) {\n    count\n  }\n}"
+        };
+        const stashIdCount = (await stash.callGQL(reqData)).data.findScenes.count;
 
-    const reqData2 = {
-        "variables": {
-            "scene_filter": {}
-        },
-        "query": "query FindScenes($filter: FindFilterType, $scene_filter: SceneFilterType, $scene_ids: [Int!]) {\n  findScenes(filter: $filter, scene_filter: $scene_filter, scene_ids: $scene_ids) {\n    count\n  }\n}"
-    };
-    const totalCount = (await stash.callGQL(reqData2)).data.findScenes.count;
+        const reqData2 = {
+            "variables": {
+                "scene_filter": {}
+            },
+            "query": "query FindScenes($filter: FindFilterType, $scene_filter: SceneFilterType, $scene_ids: [Int!]) {\n  findScenes(filter: $filter, scene_filter: $scene_filter, scene_ids: $scene_ids) {\n    count\n  }\n}"
+        };
+        const totalCount = (await stash.callGQL(reqData2)).data.findScenes.count;
 
-    createStatElement(row, (stashIdCount / totalCount * 100).toFixed(2) + '%', 'Scene StashIDs');
-}
+        createStatElement(row, (stashIdCount / totalCount * 100).toFixed(2) + '%', 'Scene StashIDs');
+    }
 
-async function createPerformerStashIDPct(row) {
-    const reqData = {
-        "variables": {
-            "performer_filter": {
-                "stash_id": {
-                    "value": "",
-                    "modifier": "NOT_NULL"
+    async function createPerformerStashIDPct(row) {
+        const reqData = {
+            "variables": {
+                "performer_filter": {
+                    "stash_id": {
+                        "value": "",
+                        "modifier": "NOT_NULL"
+                    }
                 }
-            }
-        },
-        "query": "query FindPerformers($filter: FindFilterType, $performer_filter: PerformerFilterType) {\n  findPerformers(filter: $filter, performer_filter: $performer_filter) {\n    count\n  }\n}"
-    };
-    const stashIdCount = (await stash.callGQL(reqData)).data.findPerformers.count;
+            },
+            "query": "query FindPerformers($filter: FindFilterType, $performer_filter: PerformerFilterType) {\n  findPerformers(filter: $filter, performer_filter: $performer_filter) {\n    count\n  }\n}"
+        };
+        const stashIdCount = (await stash.callGQL(reqData)).data.findPerformers.count;
 
-    const reqData2 = {
-        "variables": {
-            "performer_filter": {}
-        },
-        "query": "query FindPerformers($filter: FindFilterType, $performer_filter: PerformerFilterType) {\n  findPerformers(filter: $filter, performer_filter: $performer_filter) {\n    count\n  }\n}"
-    };
-    const totalCount = (await stash.callGQL(reqData2)).data.findPerformers.count;
+        const reqData2 = {
+            "variables": {
+                "performer_filter": {}
+            },
+            "query": "query FindPerformers($filter: FindFilterType, $performer_filter: PerformerFilterType) {\n  findPerformers(filter: $filter, performer_filter: $performer_filter) {\n    count\n  }\n}"
+        };
+        const totalCount = (await stash.callGQL(reqData2)).data.findPerformers.count;
 
-    createStatElement(row, (stashIdCount / totalCount * 100).toFixed(2) + '%', 'Performer StashIDs');
-}
+        createStatElement(row, (stashIdCount / totalCount * 100).toFixed(2) + '%', 'Performer StashIDs');
+    }
 
-async function createStudioStashIDPct(row) {
-    const reqData = {
-        "variables": {
-            "studio_filter": {
-                "stash_id": {
-                    "value": "",
-                    "modifier": "NOT_NULL"
+    async function createStudioStashIDPct(row) {
+        const reqData = {
+            "variables": {
+                "studio_filter": {
+                    "stash_id": {
+                        "value": "",
+                        "modifier": "NOT_NULL"
+                    }
                 }
+            },
+            "query": "query FindStudios($filter: FindFilterType, $studio_filter: StudioFilterType) {\n  findStudios(filter: $filter, studio_filter: $studio_filter) {\n    count\n  }\n}"
+        };
+        const stashIdCount = (await stash.callGQL(reqData)).data.findStudios.count;
+
+        const reqData2 = {
+            "variables": {
+                "scene_filter": {}
+            },
+            "query": "query FindStudios($filter: FindFilterType, $studio_filter: StudioFilterType) {\n  findStudios(filter: $filter, studio_filter: $studio_filter) {\n    count\n  }\n}"
+        };
+        const totalCount = (await stash.callGQL(reqData2)).data.findStudios.count;
+
+        createStatElement(row, (stashIdCount / totalCount * 100).toFixed(2) + '%', 'Studio StashIDs');
+    }
+
+    async function createPerformerFavorites(row) {
+        const reqData = {
+            "variables": {
+                "performer_filter": {
+                    "filter_favorites": true
+                }
+            },
+            "query": "query FindPerformers($filter: FindFilterType, $performer_filter: PerformerFilterType) {\n  findPerformers(filter: $filter, performer_filter: $performer_filter) {\n    count\n  }\n}"
+        };
+        const perfCount = (await stash.callGQL(reqData)).data.findPerformers.count;
+
+        createStatElement(row, perfCount, 'Favorite Performers');
+    }
+
+    async function createMarkersStat(row) {
+        const reqData = {
+            "variables": {
+                "scene_marker_filter": {}
+            },
+            "query": "query FindSceneMarkers($filter: FindFilterType, $scene_marker_filter: SceneMarkerFilterType) {\n  findSceneMarkers(filter: $filter, scene_marker_filter: $scene_marker_filter) {\n    count\n  }\n}"
+        };
+        const totalCount = (await stash.callGQL(reqData)).data.findSceneMarkers.count;
+
+        createStatElement(row, totalCount, 'Markers');
+    }
+
+    stash.addEventListener('page:stats', function() {
+        waitForElementByXpath("//div[contains(@class, 'container-fluid')]/div[@class='mt-5']", function(xpath, el) {
+            if (!document.getElementById('custom-stats-row')) {
+                const changelog = el.querySelector('div.changelog');
+                const row = document.createElement('div');
+                row.setAttribute('id', 'custom-stats-row');
+                row.classList.add('col', 'col-sm-8', 'm-sm-auto', 'row', 'stats');
+                el.insertBefore(row, changelog);
+
+                createSceneStashIDPct(row);
+                createStudioStashIDPct(row);
+                createPerformerStashIDPct(row);
+                createPerformerFavorites(row);
+                createMarkersStat(row);
             }
-        },
-        "query": "query FindStudios($filter: FindFilterType, $studio_filter: StudioFilterType) {\n  findStudios(filter: $filter, studio_filter: $studio_filter) {\n    count\n  }\n}"
-    };
-    const stashIdCount = (await stash.callGQL(reqData)).data.findStudios.count;
-
-    const reqData2 = {
-        "variables": {
-            "scene_filter": {}
-        },
-        "query": "query FindStudios($filter: FindFilterType, $studio_filter: StudioFilterType) {\n  findStudios(filter: $filter, studio_filter: $studio_filter) {\n    count\n  }\n}"
-    };
-    const totalCount = (await stash.callGQL(reqData2)).data.findStudios.count;
-
-    createStatElement(row, (stashIdCount / totalCount * 100).toFixed(2) + '%', 'Studio StashIDs');
-}
-
-async function createPerformerFavorites(row) {
-    const reqData = {
-        "variables": {
-            "performer_filter": {
-                "filter_favorites": true
-            }
-        },
-        "query": "query FindPerformers($filter: FindFilterType, $performer_filter: PerformerFilterType) {\n  findPerformers(filter: $filter, performer_filter: $performer_filter) {\n    count\n  }\n}"
-    };
-    const perfCount = (await stash.callGQL(reqData)).data.findPerformers.count;
-
-    createStatElement(row, perfCount, 'Favorite Performers');
-}
-
-async function createMarkersStat(row) {
-    const reqData = {
-        "variables": {
-            "scene_marker_filter": {}
-        },
-        "query": "query FindSceneMarkers($filter: FindFilterType, $scene_marker_filter: SceneMarkerFilterType) {\n  findSceneMarkers(filter: $filter, scene_marker_filter: $scene_marker_filter) {\n    count\n  }\n}"
-    };
-    const totalCount = (await stash.callGQL(reqData)).data.findSceneMarkers.count;
-
-    createStatElement(row, totalCount, 'Markers');
-}
-
-stash.addEventListener('page:stats', function() {
-    waitForElementByXpath("//div[contains(@class, 'container-fluid')]/div[@class='mt-5']", function(xpath, el) {
-        if (!document.getElementById('custom-stats-row')) {
-            const changelog = el.querySelector('div.changelog');
-            const row = document.createElement('div');
-            row.setAttribute('id', 'custom-stats-row');
-            row.classList.add('col', 'col-sm-8', 'm-sm-auto', 'row', 'stats');
-            el.insertBefore(row, changelog);
-
-            createSceneStashIDPct(row);
-            createStudioStashIDPct(row);
-            createPerformerStashIDPct(row);
-            createPerformerFavorites(row);
-            createMarkersStat(row);
-        }
+        });
     });
-});
+})();

--- a/plugins/2. stats/stats.yml
+++ b/plugins/2. stats/stats.yml
@@ -1,0 +1,6 @@
+name: Extended Stats
+description: Adds new stats to the stats page
+version: 1.0
+ui:
+  javascript:
+  - stats.js

--- a/plugins/3. Stash Batch Result Toggle/stashBatchResultToggle.js
+++ b/plugins/3. Stash Batch Result Toggle/stashBatchResultToggle.js
@@ -1,0 +1,306 @@
+let running = false;
+const buttons = [];
+let maxCount = 0;
+
+function resolveToggle(el) {
+    let button = null;
+    if (el?.classList.contains('optional-field-content')) {
+        button = el.previousElementSibling;
+    } else if (el?.tagName === 'SPAN' && el?.classList.contains('ml-auto')) {
+        button = el.querySelector('.optional-field button');
+    } else if (el?.parentElement?.classList.contains('optional-field-content')) {
+        button = el.parentElement.previousElementSibling;
+    }
+    const state = button?.classList.contains('text-success');
+    return {
+        button,
+        state
+    };
+}
+
+function toggleSearchItem(searchItem, toggleMode) {
+    const searchResultItem = searchItem.querySelector('li.search-result.selected-result.active');
+    if (!searchResultItem) return;
+
+    const {
+        urlNode,
+        url,
+        id,
+        data,
+        nameNode,
+        name,
+        queryInput,
+        performerNodes
+    } = stash.parseSearchItem(searchItem);
+
+    const {
+        remoteUrlNode,
+        remoteId,
+        remoteUrl,
+        remoteData,
+        urlNode: matchUrlNode,
+        detailsNode,
+        imageNode,
+        titleNode,
+        codeNode,
+        dateNode,
+        studioNode,
+        performerNodes: matchPerformerNodes,
+        matches
+    } = stash.parseSearchResultItem(searchResultItem);
+
+    const studioMatchNode = matches.find(o => o.matchType === 'studio')?.matchNode;
+    const performerMatchNodes = matches.filter(o => o.matchType === 'performer').map(o => o.matchNode);
+
+    const includeTitle = document.getElementById('result-toggle-title').checked;
+    const includeCode = document.getElementById('result-toggle-code').checked;
+    const includeDate = document.getElementById('result-toggle-date').checked;
+    const includeCover = document.getElementById('result-toggle-cover').checked;
+    const includeStashID = document.getElementById('result-toggle-stashid').checked;
+    const includeURL = document.getElementById('result-toggle-url').checked;
+    const includeDetails = document.getElementById('result-toggle-details').checked;
+    const includeStudio = document.getElementById('result-toggle-studio').checked;
+    const includePerformers = document.getElementById('result-toggle-performers').checked;
+
+    let options = [];
+
+    options.push(['title', includeTitle, titleNode, resolveToggle(titleNode)]);
+    options.push(['code', includeCode, codeNode, resolveToggle(codeNode)]);
+    options.push(['date', includeDate, dateNode, resolveToggle(dateNode)]);
+    options.push(['cover', includeCover, imageNode, resolveToggle(imageNode)]);
+    options.push(['stashid', includeStashID, remoteUrlNode, resolveToggle(remoteUrlNode)]);
+    options.push(['url', includeURL, matchUrlNode, resolveToggle(matchUrlNode)]);
+    options.push(['details', includeDetails, detailsNode, resolveToggle(detailsNode)]);
+    options.push(['studio', includeStudio, studioMatchNode, resolveToggle(studioMatchNode)]);
+    options = options.concat(performerMatchNodes.map(o => ['performer', includePerformers, o, resolveToggle(o)]));
+
+    for (const [optionType, optionValue, optionNode, {
+            button,
+            state
+        }] of options) {
+        let wantedState = optionValue;
+        if (toggleMode === 1) {
+            wantedState = true;
+        } else if (toggleMode === -1) {
+            wantedState = false;
+        }
+        if (optionNode && wantedState !== state) {
+            button.click();
+        }
+    }
+}
+
+function run() {
+    if (!running) return;
+    const button = buttons.pop();
+    stash.setProgress((maxCount - buttons.length) / maxCount * 100);
+    if (button) {
+        const searchItem = getClosestAncestor(button, '.search-item');
+        let toggleMode = 0;
+        if (btn === btnOn) {
+            toggleMode = 1;
+        } else if (btn === btnOff) {
+            toggleMode = -1;
+        } else if (btn === btnMixed) {
+            toggleMode = 0;
+        }
+        toggleSearchItem(searchItem, toggleMode);
+        setTimeout(run, 0);
+    } else {
+        stop();
+    }
+}
+
+const btnGroup = document.createElement('div');
+const btnGroupId = 'batch-result-toggle';
+btnGroup.setAttribute('id', btnGroupId);
+btnGroup.classList.add('btn-group', 'ml-3');
+
+const checkLabel = '<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="check" class="svg-inline--fa fa-check fa-w-16 fa-icon fa-fw" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z"></path></svg>';
+const timesLabel = '<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="times" class="svg-inline--fa fa-times fa-w-11 fa-icon fa-fw" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 352 512"><path fill="currentColor" d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"></path></svg>';
+const startLabel = '<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="circle" class="svg-inline--fa fa-circle fa-w-16 fa-icon fa-fw" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M512 256C512 397.4 397.4 512 256 512C114.6 512 0 397.4 0 256C0 114.6 114.6 0 256 0C397.4 0 512 114.6 512 256zM256 48C141.1 48 48 141.1 48 256C48 370.9 141.1 464 256 464C370.9 464 464 370.9 464 256C464 141.1 370.9 48 256 48z"/></svg>';
+let btn;
+
+const btnOffId = 'batch-result-toggle-off';
+const btnOff = document.createElement("button");
+btnOff.setAttribute("id", btnOffId);
+btnOff.title = 'Result Toggle All Off';
+btnOff.classList.add('btn', 'btn-primary');
+btnOff.innerHTML = timesLabel;
+btnOff.onclick = () => {
+    if (running) {
+        stop();
+    } else {
+        btn = btnOff;
+        start();
+    }
+};
+btnGroup.appendChild(btnOff);
+
+const btnMixedId = 'batch-result-toggle-mixed';
+const btnMixed = document.createElement("button");
+btnMixed.setAttribute("id", btnMixedId);
+btnMixed.title = 'Result Toggle All';
+btnMixed.classList.add('btn', 'btn-primary');
+btnMixed.innerHTML = startLabel;
+btnMixed.onclick = () => {
+    if (running) {
+        stop();
+    } else {
+        btn = btnMixed;
+        start();
+    }
+};
+btnGroup.appendChild(btnMixed);
+
+const btnOnId = 'batch-result-toggle-on';
+const btnOn = document.createElement("button");
+btnOn.setAttribute("id", btnOnId);
+btnOn.title = 'Result Toggle All On';
+btnOn.classList.add('btn', 'btn-primary');
+btnOn.innerHTML = checkLabel;
+btnOn.onclick = () => {
+    if (running) {
+        stop();
+    } else {
+        btn = btnOn;
+        start();
+    }
+};
+btnGroup.appendChild(btnOn);
+
+function start() {
+    // btn.innerHTML = stopLabel;
+    btn.classList.remove('btn-primary');
+    btn.classList.add('btn-danger');
+    btnMixed.disabled = true;
+    btnOn.disabled = true;
+    btnOff.disabled = true;
+    btn.disabled = false;
+    running = true;
+    stash.setProgress(0);
+    buttons.length = 0;
+    for (const button of document.querySelectorAll('.btn.btn-primary')) {
+        if (button.innerText === 'Search') {
+            buttons.push(button);
+        }
+    }
+    maxCount = buttons.length;
+    run();
+}
+
+function stop() {
+    // btn.innerHTML = startLabel;
+    btn.classList.remove('btn-danger');
+    btn.classList.add('btn-primary');
+    running = false;
+    stash.setProgress(0);
+    btnMixed.disabled = false;
+    btnOn.disabled = false;
+    btnOff.disabled = false;
+}
+
+stash.addEventListener('tagger:mutations:header', evt => {
+    const el = getElementByXpath("//button[text()='Scrape All']");
+    if (el && !document.getElementById(btnGroupId)) {
+        const container = el.parentElement;
+        container.appendChild(btnGroup);
+        sortElementChildren(container);
+        el.classList.add('ml-3');
+    }
+});
+
+const resultToggleConfigId = 'result-toggle-config';
+
+stash.addEventListener('tagger:configuration', evt => {
+    const el = evt.detail;
+    if (!document.getElementById(resultToggleConfigId)) {
+        const configContainer = el.parentElement;
+        const resultToggleConfig = createElementFromHTML(`
+<div id="${resultToggleConfigId}" class="col-md-6 mt-4">
+<h5>Result Toggle ${startLabel} Configuration</h5>
+<div class="row">
+    <div class="align-items-center form-group col-md-6">
+        <div class="form-check">
+            <input type="checkbox" id="result-toggle-title" class="form-check-input" data-default="true">
+            <label title="" for="result-toggle-title" class="form-check-label">Title</label>
+        </div>
+    </div>
+    <div class="align-items-center form-group col-md-6">
+        <div class="form-check">
+            <input type="checkbox" id="result-toggle-code" class="form-check-input" data-default="true">
+            <label title="" for="result-toggle-code" class="form-check-label">Code</label>
+        </div>
+    </div>
+    <div class="align-items-center form-group col-md-6">
+        <div class="form-check">
+            <input type="checkbox" id="result-toggle-date" class="form-check-input" data-default="true">
+            <label title="" for="result-toggle-date" class="form-check-label">Date</label>
+        </div>
+    </div>
+    <div class="align-items-center form-group col-md-6">
+        <div class="form-check">
+            <input type="checkbox" id="result-toggle-cover" class="form-check-input" data-default="true">
+            <label title="" for="result-toggle-cover" class="form-check-label">Cover</label>
+        </div>
+    </div>
+    <div class="align-items-center form-group col-md-6">
+        <div class="form-check">
+            <input type="checkbox" id="result-toggle-stashid" class="form-check-input" data-default="true">
+            <label title="" for="result-toggle-stashid" class="form-check-label">Stash ID</label>
+        </div>
+    </div>
+    <div class="align-items-center form-group col-md-6">
+        <div class="form-check">
+            <input type="checkbox" id="result-toggle-url" class="form-check-input" data-default="true">
+            <label title="" for="result-toggle-url" class="form-check-label">URL</label>
+        </div>
+    </div>
+    <div class="align-items-center form-group col-md-6">
+        <div class="form-check">
+            <input type="checkbox" id="result-toggle-details" class="form-check-input" data-default="true">
+            <label title="" for="result-toggle-details" class="form-check-label">Details</label>
+        </div>
+    </div>
+    <div class="align-items-center form-group col-md-6">
+        <div class="form-check">
+            <input type="checkbox" id="result-toggle-studio" class="form-check-input" data-default="true">
+            <label title="" for="result-toggle-studio" class="form-check-label">Studio</label>
+        </div>
+    </div>
+    <div class="align-items-center form-group col-md-6">
+        <div class="form-check">
+            <input type="checkbox" id="result-toggle-performers" class="form-check-input" data-default="true">
+            <label title="" for="result-toggle-performers" class="form-check-label">Performers</label>
+        </div>
+    </div>
+</div>
+</div>
+            `);
+        configContainer.appendChild(resultToggleConfig);
+        loadSettings();
+    }
+});
+
+async function loadSettings() {
+    for (const input of document.querySelectorAll(`#${resultToggleConfigId} input`)) {
+        input.checked = await sessionStorage.getItem(input.id, input.dataset.default === 'true');
+        input.addEventListener('change', async () => {
+            await sessionStorage.setItem(input.id, input.checked);
+        });
+    }
+}
+
+stash.addEventListener('tagger:mutation:add:remoteperformer', evt => toggleSearchItem(getClosestAncestor(evt.detail.node, '.search-item'), 0));
+stash.addEventListener('tagger:mutation:add:remotestudio', evt => toggleSearchItem(getClosestAncestor(evt.detail.node, '.search-item'), 0));
+stash.addEventListener('tagger:mutation:add:local', evt => toggleSearchItem(getClosestAncestor(evt.detail.node, '.search-item'), 0));
+stash.addEventListener('tagger:mutation:add:container', evt => toggleSearchItem(getClosestAncestor(evt.detail.node, '.search-item'), 0));
+stash.addEventListener('tagger:mutation:add:subcontainer', evt => toggleSearchItem(getClosestAncestor(evt.detail.node, '.search-item'), 0));
+
+function checkSaveButtonDisplay() {
+    const taggerContainer = document.querySelector('.tagger-container');
+    const saveButton = getElementByXpath("//button[text()='Save']", taggerContainer);
+    btnGroup.style.display = saveButton ? 'inline-block' : 'none';
+}
+
+stash.addEventListener('tagger:mutations:searchitems', checkSaveButtonDisplay);

--- a/plugins/3. Stash Batch Result Toggle/stashBatchResultToggle.js
+++ b/plugins/3. Stash Batch Result Toggle/stashBatchResultToggle.js
@@ -1,222 +1,223 @@
-let running = false;
-const buttons = [];
-let maxCount = 0;
+(function() {
+    let running = false;
+    const buttons = [];
+    let maxCount = 0;
 
-function resolveToggle(el) {
-    let button = null;
-    if (el?.classList.contains('optional-field-content')) {
-        button = el.previousElementSibling;
-    } else if (el?.tagName === 'SPAN' && el?.classList.contains('ml-auto')) {
-        button = el.querySelector('.optional-field button');
-    } else if (el?.parentElement?.classList.contains('optional-field-content')) {
-        button = el.parentElement.previousElementSibling;
-    }
-    const state = button?.classList.contains('text-success');
-    return {
-        button,
-        state
-    };
-}
-
-function toggleSearchItem(searchItem, toggleMode) {
-    const searchResultItem = searchItem.querySelector('li.search-result.selected-result.active');
-    if (!searchResultItem) return;
-
-    const {
-        urlNode,
-        url,
-        id,
-        data,
-        nameNode,
-        name,
-        queryInput,
-        performerNodes
-    } = stash.parseSearchItem(searchItem);
-
-    const {
-        remoteUrlNode,
-        remoteId,
-        remoteUrl,
-        remoteData,
-        urlNode: matchUrlNode,
-        detailsNode,
-        imageNode,
-        titleNode,
-        codeNode,
-        dateNode,
-        studioNode,
-        performerNodes: matchPerformerNodes,
-        matches
-    } = stash.parseSearchResultItem(searchResultItem);
-
-    const studioMatchNode = matches.find(o => o.matchType === 'studio')?.matchNode;
-    const performerMatchNodes = matches.filter(o => o.matchType === 'performer').map(o => o.matchNode);
-
-    const includeTitle = document.getElementById('result-toggle-title').checked;
-    const includeCode = document.getElementById('result-toggle-code').checked;
-    const includeDate = document.getElementById('result-toggle-date').checked;
-    const includeCover = document.getElementById('result-toggle-cover').checked;
-    const includeStashID = document.getElementById('result-toggle-stashid').checked;
-    const includeURL = document.getElementById('result-toggle-url').checked;
-    const includeDetails = document.getElementById('result-toggle-details').checked;
-    const includeStudio = document.getElementById('result-toggle-studio').checked;
-    const includePerformers = document.getElementById('result-toggle-performers').checked;
-
-    let options = [];
-
-    options.push(['title', includeTitle, titleNode, resolveToggle(titleNode)]);
-    options.push(['code', includeCode, codeNode, resolveToggle(codeNode)]);
-    options.push(['date', includeDate, dateNode, resolveToggle(dateNode)]);
-    options.push(['cover', includeCover, imageNode, resolveToggle(imageNode)]);
-    options.push(['stashid', includeStashID, remoteUrlNode, resolveToggle(remoteUrlNode)]);
-    options.push(['url', includeURL, matchUrlNode, resolveToggle(matchUrlNode)]);
-    options.push(['details', includeDetails, detailsNode, resolveToggle(detailsNode)]);
-    options.push(['studio', includeStudio, studioMatchNode, resolveToggle(studioMatchNode)]);
-    options = options.concat(performerMatchNodes.map(o => ['performer', includePerformers, o, resolveToggle(o)]));
-
-    for (const [optionType, optionValue, optionNode, {
+    function resolveToggle(el) {
+        let button = null;
+        if (el?.classList.contains('optional-field-content')) {
+            button = el.previousElementSibling;
+        } else if (el?.tagName === 'SPAN' && el?.classList.contains('ml-auto')) {
+            button = el.querySelector('.optional-field button');
+        } else if (el?.parentElement?.classList.contains('optional-field-content')) {
+            button = el.parentElement.previousElementSibling;
+        }
+        const state = button?.classList.contains('text-success');
+        return {
             button,
             state
-        }] of options) {
-        let wantedState = optionValue;
-        if (toggleMode === 1) {
-            wantedState = true;
-        } else if (toggleMode === -1) {
-            wantedState = false;
-        }
-        if (optionNode && wantedState !== state) {
-            button.click();
-        }
+        };
     }
-}
 
-function run() {
-    if (!running) return;
-    const button = buttons.pop();
-    stash.setProgress((maxCount - buttons.length) / maxCount * 100);
-    if (button) {
-        const searchItem = getClosestAncestor(button, '.search-item');
-        let toggleMode = 0;
-        if (btn === btnOn) {
-            toggleMode = 1;
-        } else if (btn === btnOff) {
-            toggleMode = -1;
-        } else if (btn === btnMixed) {
-            toggleMode = 0;
-        }
-        toggleSearchItem(searchItem, toggleMode);
-        setTimeout(run, 0);
-    } else {
-        stop();
-    }
-}
+    function toggleSearchItem(searchItem, toggleMode) {
+        const searchResultItem = searchItem.querySelector('li.search-result.selected-result.active');
+        if (!searchResultItem) return;
 
-const btnGroup = document.createElement('div');
-const btnGroupId = 'batch-result-toggle';
-btnGroup.setAttribute('id', btnGroupId);
-btnGroup.classList.add('btn-group', 'ml-3');
+        const {
+            urlNode,
+            url,
+            id,
+            data,
+            nameNode,
+            name,
+            queryInput,
+            performerNodes
+        } = stash.parseSearchItem(searchItem);
 
-const checkLabel = '<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="check" class="svg-inline--fa fa-check fa-w-16 fa-icon fa-fw" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z"></path></svg>';
-const timesLabel = '<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="times" class="svg-inline--fa fa-times fa-w-11 fa-icon fa-fw" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 352 512"><path fill="currentColor" d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"></path></svg>';
-const startLabel = '<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="circle" class="svg-inline--fa fa-circle fa-w-16 fa-icon fa-fw" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M512 256C512 397.4 397.4 512 256 512C114.6 512 0 397.4 0 256C0 114.6 114.6 0 256 0C397.4 0 512 114.6 512 256zM256 48C141.1 48 48 141.1 48 256C48 370.9 141.1 464 256 464C370.9 464 464 370.9 464 256C464 141.1 370.9 48 256 48z"/></svg>';
-let btn;
+        const {
+            remoteUrlNode,
+            remoteId,
+            remoteUrl,
+            remoteData,
+            urlNode: matchUrlNode,
+            detailsNode,
+            imageNode,
+            titleNode,
+            codeNode,
+            dateNode,
+            studioNode,
+            performerNodes: matchPerformerNodes,
+            matches
+        } = stash.parseSearchResultItem(searchResultItem);
 
-const btnOffId = 'batch-result-toggle-off';
-const btnOff = document.createElement("button");
-btnOff.setAttribute("id", btnOffId);
-btnOff.title = 'Result Toggle All Off';
-btnOff.classList.add('btn', 'btn-primary');
-btnOff.innerHTML = timesLabel;
-btnOff.onclick = () => {
-    if (running) {
-        stop();
-    } else {
-        btn = btnOff;
-        start();
-    }
-};
-btnGroup.appendChild(btnOff);
+        const studioMatchNode = matches.find(o => o.matchType === 'studio')?.matchNode;
+        const performerMatchNodes = matches.filter(o => o.matchType === 'performer').map(o => o.matchNode);
 
-const btnMixedId = 'batch-result-toggle-mixed';
-const btnMixed = document.createElement("button");
-btnMixed.setAttribute("id", btnMixedId);
-btnMixed.title = 'Result Toggle All';
-btnMixed.classList.add('btn', 'btn-primary');
-btnMixed.innerHTML = startLabel;
-btnMixed.onclick = () => {
-    if (running) {
-        stop();
-    } else {
-        btn = btnMixed;
-        start();
-    }
-};
-btnGroup.appendChild(btnMixed);
+        const includeTitle = document.getElementById('result-toggle-title').checked;
+        const includeCode = document.getElementById('result-toggle-code').checked;
+        const includeDate = document.getElementById('result-toggle-date').checked;
+        const includeCover = document.getElementById('result-toggle-cover').checked;
+        const includeStashID = document.getElementById('result-toggle-stashid').checked;
+        const includeURL = document.getElementById('result-toggle-url').checked;
+        const includeDetails = document.getElementById('result-toggle-details').checked;
+        const includeStudio = document.getElementById('result-toggle-studio').checked;
+        const includePerformers = document.getElementById('result-toggle-performers').checked;
 
-const btnOnId = 'batch-result-toggle-on';
-const btnOn = document.createElement("button");
-btnOn.setAttribute("id", btnOnId);
-btnOn.title = 'Result Toggle All On';
-btnOn.classList.add('btn', 'btn-primary');
-btnOn.innerHTML = checkLabel;
-btnOn.onclick = () => {
-    if (running) {
-        stop();
-    } else {
-        btn = btnOn;
-        start();
-    }
-};
-btnGroup.appendChild(btnOn);
+        let options = [];
 
-function start() {
-    // btn.innerHTML = stopLabel;
-    btn.classList.remove('btn-primary');
-    btn.classList.add('btn-danger');
-    btnMixed.disabled = true;
-    btnOn.disabled = true;
-    btnOff.disabled = true;
-    btn.disabled = false;
-    running = true;
-    stash.setProgress(0);
-    buttons.length = 0;
-    for (const button of document.querySelectorAll('.btn.btn-primary')) {
-        if (button.innerText === 'Search') {
-            buttons.push(button);
+        options.push(['title', includeTitle, titleNode, resolveToggle(titleNode)]);
+        options.push(['code', includeCode, codeNode, resolveToggle(codeNode)]);
+        options.push(['date', includeDate, dateNode, resolveToggle(dateNode)]);
+        options.push(['cover', includeCover, imageNode, resolveToggle(imageNode)]);
+        options.push(['stashid', includeStashID, remoteUrlNode, resolveToggle(remoteUrlNode)]);
+        options.push(['url', includeURL, matchUrlNode, resolveToggle(matchUrlNode)]);
+        options.push(['details', includeDetails, detailsNode, resolveToggle(detailsNode)]);
+        options.push(['studio', includeStudio, studioMatchNode, resolveToggle(studioMatchNode)]);
+        options = options.concat(performerMatchNodes.map(o => ['performer', includePerformers, o, resolveToggle(o)]));
+
+        for (const [optionType, optionValue, optionNode, {
+                button,
+                state
+            }] of options) {
+            let wantedState = optionValue;
+            if (toggleMode === 1) {
+                wantedState = true;
+            } else if (toggleMode === -1) {
+                wantedState = false;
+            }
+            if (optionNode && wantedState !== state) {
+                button.click();
+            }
         }
     }
-    maxCount = buttons.length;
-    run();
-}
 
-function stop() {
-    // btn.innerHTML = startLabel;
-    btn.classList.remove('btn-danger');
-    btn.classList.add('btn-primary');
-    running = false;
-    stash.setProgress(0);
-    btnMixed.disabled = false;
-    btnOn.disabled = false;
-    btnOff.disabled = false;
-}
-
-stash.addEventListener('tagger:mutations:header', evt => {
-    const el = getElementByXpath("//button[text()='Scrape All']");
-    if (el && !document.getElementById(btnGroupId)) {
-        const container = el.parentElement;
-        container.appendChild(btnGroup);
-        sortElementChildren(container);
-        el.classList.add('ml-3');
+    function run() {
+        if (!running) return;
+        const button = buttons.pop();
+        stash.setProgress((maxCount - buttons.length) / maxCount * 100);
+        if (button) {
+            const searchItem = getClosestAncestor(button, '.search-item');
+            let toggleMode = 0;
+            if (btn === btnOn) {
+                toggleMode = 1;
+            } else if (btn === btnOff) {
+                toggleMode = -1;
+            } else if (btn === btnMixed) {
+                toggleMode = 0;
+            }
+            toggleSearchItem(searchItem, toggleMode);
+            setTimeout(run, 0);
+        } else {
+            stop();
+        }
     }
-});
 
-const resultToggleConfigId = 'result-toggle-config';
+    const btnGroup = document.createElement('div');
+    const btnGroupId = 'batch-result-toggle';
+    btnGroup.setAttribute('id', btnGroupId);
+    btnGroup.classList.add('btn-group', 'ml-3');
 
-stash.addEventListener('tagger:configuration', evt => {
-    const el = evt.detail;
-    if (!document.getElementById(resultToggleConfigId)) {
-        const configContainer = el.parentElement;
-        const resultToggleConfig = createElementFromHTML(`
+    const checkLabel = '<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="check" class="svg-inline--fa fa-check fa-w-16 fa-icon fa-fw" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z"></path></svg>';
+    const timesLabel = '<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="times" class="svg-inline--fa fa-times fa-w-11 fa-icon fa-fw" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 352 512"><path fill="currentColor" d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"></path></svg>';
+    const startLabel = '<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="circle" class="svg-inline--fa fa-circle fa-w-16 fa-icon fa-fw" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M512 256C512 397.4 397.4 512 256 512C114.6 512 0 397.4 0 256C0 114.6 114.6 0 256 0C397.4 0 512 114.6 512 256zM256 48C141.1 48 48 141.1 48 256C48 370.9 141.1 464 256 464C370.9 464 464 370.9 464 256C464 141.1 370.9 48 256 48z"/></svg>';
+    let btn;
+
+    const btnOffId = 'batch-result-toggle-off';
+    const btnOff = document.createElement("button");
+    btnOff.setAttribute("id", btnOffId);
+    btnOff.title = 'Result Toggle All Off';
+    btnOff.classList.add('btn', 'btn-primary');
+    btnOff.innerHTML = timesLabel;
+    btnOff.onclick = () => {
+        if (running) {
+            stop();
+        } else {
+            btn = btnOff;
+            start();
+        }
+    };
+    btnGroup.appendChild(btnOff);
+
+    const btnMixedId = 'batch-result-toggle-mixed';
+    const btnMixed = document.createElement("button");
+    btnMixed.setAttribute("id", btnMixedId);
+    btnMixed.title = 'Result Toggle All';
+    btnMixed.classList.add('btn', 'btn-primary');
+    btnMixed.innerHTML = startLabel;
+    btnMixed.onclick = () => {
+        if (running) {
+            stop();
+        } else {
+            btn = btnMixed;
+            start();
+        }
+    };
+    btnGroup.appendChild(btnMixed);
+
+    const btnOnId = 'batch-result-toggle-on';
+    const btnOn = document.createElement("button");
+    btnOn.setAttribute("id", btnOnId);
+    btnOn.title = 'Result Toggle All On';
+    btnOn.classList.add('btn', 'btn-primary');
+    btnOn.innerHTML = checkLabel;
+    btnOn.onclick = () => {
+        if (running) {
+            stop();
+        } else {
+            btn = btnOn;
+            start();
+        }
+    };
+    btnGroup.appendChild(btnOn);
+
+    function start() {
+        // btn.innerHTML = stopLabel;
+        btn.classList.remove('btn-primary');
+        btn.classList.add('btn-danger');
+        btnMixed.disabled = true;
+        btnOn.disabled = true;
+        btnOff.disabled = true;
+        btn.disabled = false;
+        running = true;
+        stash.setProgress(0);
+        buttons.length = 0;
+        for (const button of document.querySelectorAll('.btn.btn-primary')) {
+            if (button.innerText === 'Search') {
+                buttons.push(button);
+            }
+        }
+        maxCount = buttons.length;
+        run();
+    }
+
+    function stop() {
+        // btn.innerHTML = startLabel;
+        btn.classList.remove('btn-danger');
+        btn.classList.add('btn-primary');
+        running = false;
+        stash.setProgress(0);
+        btnMixed.disabled = false;
+        btnOn.disabled = false;
+        btnOff.disabled = false;
+    }
+
+    stash.addEventListener('tagger:mutations:header', evt => {
+        const el = getElementByXpath("//button[text()='Scrape All']");
+        if (el && !document.getElementById(btnGroupId)) {
+            const container = el.parentElement;
+            container.appendChild(btnGroup);
+            sortElementChildren(container);
+            el.classList.add('ml-3');
+        }
+    });
+
+    const resultToggleConfigId = 'result-toggle-config';
+
+    stash.addEventListener('tagger:configuration', evt => {
+        const el = evt.detail;
+        if (!document.getElementById(resultToggleConfigId)) {
+            const configContainer = el.parentElement;
+            const resultToggleConfig = createElementFromHTML(`
 <div id="${resultToggleConfigId}" class="col-md-6 mt-4">
 <h5>Result Toggle ${startLabel} Configuration</h5>
 <div class="row">
@@ -277,30 +278,31 @@ stash.addEventListener('tagger:configuration', evt => {
 </div>
 </div>
             `);
-        configContainer.appendChild(resultToggleConfig);
-        loadSettings();
+            configContainer.appendChild(resultToggleConfig);
+            loadSettings();
+        }
+    });
+
+    async function loadSettings() {
+        for (const input of document.querySelectorAll(`#${resultToggleConfigId} input`)) {
+            input.checked = await sessionStorage.getItem(input.id, input.dataset.default === 'true');
+            input.addEventListener('change', async () => {
+                await sessionStorage.setItem(input.id, input.checked);
+            });
+        }
     }
-});
 
-async function loadSettings() {
-    for (const input of document.querySelectorAll(`#${resultToggleConfigId} input`)) {
-        input.checked = await sessionStorage.getItem(input.id, input.dataset.default === 'true');
-        input.addEventListener('change', async () => {
-            await sessionStorage.setItem(input.id, input.checked);
-        });
+    stash.addEventListener('tagger:mutation:add:remoteperformer', evt => toggleSearchItem(getClosestAncestor(evt.detail.node, '.search-item'), 0));
+    stash.addEventListener('tagger:mutation:add:remotestudio', evt => toggleSearchItem(getClosestAncestor(evt.detail.node, '.search-item'), 0));
+    stash.addEventListener('tagger:mutation:add:local', evt => toggleSearchItem(getClosestAncestor(evt.detail.node, '.search-item'), 0));
+    stash.addEventListener('tagger:mutation:add:container', evt => toggleSearchItem(getClosestAncestor(evt.detail.node, '.search-item'), 0));
+    stash.addEventListener('tagger:mutation:add:subcontainer', evt => toggleSearchItem(getClosestAncestor(evt.detail.node, '.search-item'), 0));
+
+    function checkSaveButtonDisplay() {
+        const taggerContainer = document.querySelector('.tagger-container');
+        const saveButton = getElementByXpath("//button[text()='Save']", taggerContainer);
+        btnGroup.style.display = saveButton ? 'inline-block' : 'none';
     }
-}
 
-stash.addEventListener('tagger:mutation:add:remoteperformer', evt => toggleSearchItem(getClosestAncestor(evt.detail.node, '.search-item'), 0));
-stash.addEventListener('tagger:mutation:add:remotestudio', evt => toggleSearchItem(getClosestAncestor(evt.detail.node, '.search-item'), 0));
-stash.addEventListener('tagger:mutation:add:local', evt => toggleSearchItem(getClosestAncestor(evt.detail.node, '.search-item'), 0));
-stash.addEventListener('tagger:mutation:add:container', evt => toggleSearchItem(getClosestAncestor(evt.detail.node, '.search-item'), 0));
-stash.addEventListener('tagger:mutation:add:subcontainer', evt => toggleSearchItem(getClosestAncestor(evt.detail.node, '.search-item'), 0));
-
-function checkSaveButtonDisplay() {
-    const taggerContainer = document.querySelector('.tagger-container');
-    const saveButton = getElementByXpath("//button[text()='Save']", taggerContainer);
-    btnGroup.style.display = saveButton ? 'inline-block' : 'none';
-}
-
-stash.addEventListener('tagger:mutations:searchitems', checkSaveButtonDisplay);
+    stash.addEventListener('tagger:mutations:searchitems', checkSaveButtonDisplay);
+})();

--- a/plugins/3. Stash Batch Result Toggle/stashBatchResultToggle.yml
+++ b/plugins/3. Stash Batch Result Toggle/stashBatchResultToggle.yml
@@ -1,0 +1,6 @@
+name: Stash Batch Result Toggle.
+description: In Scene Tagger, adds button to toggle all stashdb scene match result fields. Saves clicks when you only want to save a few metadata fields. Instead of turning off every field, you batch toggle them off, then toggle on the ones you want
+version: 1.0
+ui:
+  javascript:
+  - stashBatchResultToggle.js


### PR DESCRIPTION
I've refactored @7dJx1qP/redsheep1's  Stash Userscript Library such that it can be used for plugin development directly into Stash. That library has made it easy for many users to build on, to create various user scripts. My thinking is that if the library was made available for plugin development, user scripts that could have been provided as a plugin could easily be transitioned into a plugin.

You must ensure the library is loaded before other scripts, so I have numbered the directories to enforce a load order. From there, I basically copied the content of the Stash Stats user script and provided it as its own plugin.