### PR TITLE
Use #pkgignore to omit from build script

### DIFF
--- a/build_site.sh
+++ b/build_site.sh
@@ -17,6 +17,11 @@ mkdir -p "$outdir"
 buildPlugin() 
 {
     f=$1
+
+    if grep -q "^#pkgignore" "$f"; then
+        return
+    fi
+    
     # get the scraper id from the directory
     dir=$(dirname "$f")
     plugin_id=$(basename "$f" .yml)

--- a/plugins/comicInfoExtractor/config.yml
+++ b/plugins/comicInfoExtractor/config.yml
@@ -1,3 +1,4 @@
+#pkgignore
 #ImportList is a dictionary
 #that matches an xml Attribute from ComicInfo.xml to the according value in stash (using the graphql naming)
 #Fields that refer to different types of media are resolved by name and created if necessary (tags, studio, performers)


### PR DESCRIPTION
Changed the site building script to ignore yml files when they contain `#pkgignore`