### PR TITLE
v2.5.0 - limited changes to work with Stash v24 - STOPGAP RELEASE

### DIFF
--- a/plugins/renamerOnUpdate/README.md
+++ b/plugins/renamerOnUpdate/README.md
@@ -1,6 +1,17 @@
 # *renamerOnUpdate*
 Using metadata from your Stash to rename/move your file.
 
+# WARNING - This is a stopgap release
+It is labeled 2.5.0, to fill the gap until v3.0 is released
+It is NOT heavily tested, with the bare minimum needed to work with Stash v24
+Version 3 is a major rewrite, but since it's not quite ready, pushing 2.5.0 seems necessary
+It worked for me, using my old config, and I got no errors during my limited tests.
+YOU HAVE BEEN WARNED - any potential data loss is on you.
+BEFORE YOU USE IT TO MOVE/RENAME ANYTHING CRITICAL, test it yourself.
+I still suggest you wait for v3, but... if you can't, this is now out.
+
+All credit to Belley for all of his work over the years... and v3 is coming soon
+
 ## Table of Contents  
 
 - [*renamerOnUpdate*](#renameronupdate)
@@ -33,10 +44,9 @@ Using metadata from your Stash to rename/move your file.
 		- [*performer_limit*](#performer_limit)
 
 # Requirement
-- Stash (v0.15+)
-- Python 3.6+ (Tested on Python v3.9.1 64bit, Win10)
+- Stash (v0.24+)
+- Python 3.6+ (Tested LIGHTLY on Python v3.11 Linux)
 - Request Module (https://pypi.org/project/requests/)
-- Tested on Windows 10/Synology/docker.
 
 # Installation
 

--- a/plugins/renamerOnUpdate/renamerOnUpdate.yml
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.yml
@@ -1,7 +1,7 @@
 name: renamerOnUpdate
 description: Rename/move filename based on a template.
 url: https://github.com/stashapp/CommunityScripts
-version: 2.4.4
+version: 2.5.0
 exec:
   - python
   - "{pluginDir}/renamerOnUpdate.py"


### PR DESCRIPTION
As the README says:

# WARNING - This is a stopgap release
It is labeled 2.5.0, to fill the gap until v3.0 is released
It is NOT heavily tested, with the bare minimum needed to work with Stash v24
Version 3 is a major rewrite, but since it's not quite ready, pushing 2.5.0 seems necessary
It worked for me, using my old config, and I got no errors during my limited tests.
YOU HAVE BEEN WARNED - any potential data loss is on you.
BEFORE YOU USE IT TO MOVE/RENAME ANYTHING CRITICAL, test it yourself.
I still suggest you wait for v3, but... if you can't, this is now out.