### PR TITLE
bugfix,  timestampTrade.py set a default config value

### DIFF
--- a/plugins/timestampTrade/timestampTrade.py
+++ b/plugins/timestampTrade/timestampTrade.py
@@ -456,6 +456,7 @@ config=stash.get_configuration()['plugins']
 settings={
     'createGalleryFromScene':True,
     'createMovieFromScene':True,
+    'extraUrls':True,
  }
 if 'timestampTrade' in config:
     settings.update(config['timestampTrade'])


### PR DESCRIPTION
Bugfix, set a default value for the config option as it does not exist in the plugin config until the value has been set.