### PR TITLE
Update stashdb-performer-gallery.py

### DIFF
--- a/plugins/stashdb-performer-gallery/stashdb-performer-gallery.py
+++ b/plugins/stashdb-performer-gallery/stashdb-performer-gallery.py
@@ -43,6 +43,8 @@ def processPerformers():
 def processPerformer( performer):
     dir=Path(settings['path']) / performer['id']
     dir.mkdir(parents=True, exist_ok=True)
+    nogallery=dir / '.nogallery'
+    nogallery.touch()
     for sid in performer['stash_ids']:
         log.debug(sid)
         processPerformerStashid(sid['endpoint'],sid['stash_id'],performer)


### PR DESCRIPTION
Bugfix, create a .nogallery file in the directory so the built in gallery does not get created when "Create galleries from folders containing images" is enabled.