### PR TITLE
Make builds deterministic and reproducible

### DIFF
--- a/build_site.sh
+++ b/build_site.sh
@@ -37,7 +37,8 @@ buildPlugin()
     zipfile=$(realpath "$outdir/$plugin_id.zip")
     
     pushd "$dir" > /dev/null
-    zip -r "$zipfile" . > /dev/null
+    find . -type f -exec touch -d "$updated" {} +
+    grep -rl . | sort | zip -0 -r -oX "$zipfile" -@ > /dev/null
     popd > /dev/null
 
     name=$(grep "^name:" "$f" | head -n 1 | cut -d' ' -f2- | sed -e 's/\r//' -e 's/^"\(.*\)"$/\1/')
@@ -67,9 +68,9 @@ buildPlugin()
     echo "" >> "$outdir"/index.yml
 }
 
-find ./plugins -mindepth 1 -name *.yml | while read file; do
+find ./plugins -mindepth 1 -name *.yml | sort | while read file; do
     buildPlugin "$file"
 done
-find ./themes -mindepth 1 -name *.yml | while read file; do
+find ./themes -mindepth 1 -name *.yml | sort | while read file; do
     buildPlugin "$file"
 done


### PR DESCRIPTION
The current `build_site.sh` script generates a new hash for every deployment even if the plugin hasn't changed. The reason the hashes change is due to file timestamps changing when the build checks out the repo and file order when creating the zip.

To address this, I've updated the script so that it sets each file timestamp to the updated date that's already being used and sorts the files that it zips. I also added sorting of the plugins and themes in the index.yml