### PR TITLE
[plugin][phashDuplicateTagger] Add ability to compare by created_at

### DIFF
--- a/plugins/phashDuplicateTagger/config.py
+++ b/plugins/phashDuplicateTagger/config.py
@@ -1,7 +1,7 @@
 import stashapi.log as log
 from stashapi.tools import human_bytes, human_bits
 
-PRIORITY = ["bitrate_per_pixel", "resolution", "bitrate", "encoding", "size", "age_mod_time"]
+PRIORITY = ["bitrate_per_pixel", "resolution", "bitrate", "encoding", "size", "age"]
 CODEC_PRIORITY = {
     "AV1": 0,
     "H265": 1,
@@ -112,23 +112,7 @@ def compare_size(self, other):
     )
 
 
-def compare_age_mod_time(self, other):
-    if not (self.mod_time and other.mod_time):
-        return
-    if self.mod_time == other.mod_time:
-        return
-    if self.mod_time < other.mod_time:
-        better, worse = self, other
-    else:
-        worse, better = self, other
-    worse.remove_reason = "age_mod_time"
-    return (
-        better,
-        f"Choose Oldest by Update Time: Δ:{worse.mod_time-better.mod_time} | {better.id} older than {worse.id}",
-    )
-
-
-def compare_age_created_at(self, other):
+def compare_age(self, other):
     if not (self.created_at and other.created_at):
         return
     if self.created_at == other.created_at:
@@ -137,10 +121,10 @@ def compare_age_created_at(self, other):
         better, worse = self, other
     else:
         worse, better = self, other
-    worse.remove_reason = "age_created_at"
+    worse.remove_reason = "age"
     return (
         better,
-        f"Choose Oldest by Create Time: Δ:{worse.mod_time-better.mod_time} | {better.id} older than {worse.id}",
+        f"Choose Oldest: Δ:{worse.created_at-better.created_at} | {better.id} older than {worse.id}",
     )
 
 

--- a/plugins/phashDuplicateTagger/config.py
+++ b/plugins/phashDuplicateTagger/config.py
@@ -1,7 +1,7 @@
 import stashapi.log as log
 from stashapi.tools import human_bytes, human_bits
 
-PRIORITY = ["bitrate_per_pixel", "resolution", "bitrate", "encoding", "size", "age"]
+PRIORITY = ["bitrate_per_pixel", "resolution", "bitrate", "encoding", "size", "age_mod_time"]
 CODEC_PRIORITY = {
     "AV1": 0,
     "H265": 1,
@@ -112,7 +112,7 @@ def compare_size(self, other):
     )
 
 
-def compare_age(self, other):
+def compare_age_mod_time(self, other):
     if not (self.mod_time and other.mod_time):
         return
     if self.mod_time == other.mod_time:
@@ -121,10 +121,26 @@ def compare_age(self, other):
         better, worse = self, other
     else:
         worse, better = self, other
-    worse.remove_reason = "age"
+    worse.remove_reason = "age_mod_time"
     return (
         better,
-        f"Choose Oldest: Δ:{worse.mod_time-better.mod_time} | {better.id} older than {worse.id}",
+        f"Choose Oldest by Update Time: Δ:{worse.mod_time-better.mod_time} | {better.id} older than {worse.id}",
+    )
+
+
+def compare_age_created_at(self, other):
+    if not (self.created_at and other.created_at):
+        return
+    if self.created_at == other.created_at:
+        return
+    if self.created_at < other.created_at:
+        better, worse = self, other
+    else:
+        worse, better = self, other
+    worse.remove_reason = "age_created_at"
+    return (
+        better,
+        f"Choose Oldest by Create Time: Δ:{worse.mod_time-better.mod_time} | {better.id} older than {worse.id}",
     )
 
 

--- a/plugins/phashDuplicateTagger/phashDuplicateTagger.py
+++ b/plugins/phashDuplicateTagger/phashDuplicateTagger.py
@@ -31,6 +31,7 @@ files {
 	height
 	bit_rate
 	mod_time
+	created_at
 	duration
 	frame_rate
 	video_codec
@@ -72,6 +73,7 @@ class StashScene:
 
         self.id = int(scene["id"])
         self.mod_time = parse_timestamp(file["mod_time"])
+        self.created_at = parse_timestamp(file["created_at"])
         if scene.get("date"):
             self.date = parse_timestamp(scene["date"], format="%Y-%m-%d")
         else:

--- a/plugins/phashDuplicateTagger/phashDuplicateTagger.py
+++ b/plugins/phashDuplicateTagger/phashDuplicateTagger.py
@@ -30,7 +30,6 @@ files {
 	width
 	height
 	bit_rate
-	mod_time
 	created_at
 	duration
 	frame_rate
@@ -72,7 +71,6 @@ class StashScene:
         file = scene["files"][0]
 
         self.id = int(scene["id"])
-        self.mod_time = parse_timestamp(file["mod_time"])
         self.created_at = parse_timestamp(file["created_at"])
         if scene.get("date"):
             self.date = parse_timestamp(scene["date"], format="%Y-%m-%d")
@@ -104,7 +102,7 @@ class StashScene:
         return f"<StashScene ({self.id})>"
 
     def __str__(self) -> str:
-        return f"id:{self.id}, height:{self.height}, size:{human_bytes(self.size)}, file_mod_time:{self.mod_time}, title:{self.title}"
+        return f"id:{self.id}, height:{self.height}, size:{human_bytes(self.size)}, file_created_at:{self.created_at}, title:{self.title}"
 
     def compare(self, other):
         if not (isinstance(other, StashScene)):


### PR DESCRIPTION
This PR adds ability to compare the "created_at" time between files instead of just the "mod_time".

This PR does break some backward compatibility, as "compare_age" is now a bit too broad, so it was renamed to "compare_age_mod_time".  

We could leave "compare_age" alone and simply add "compare_age_created_at" if that is preferable to avoid breakage.