### PR TITLE
Allow disabling scene marker hooks

### DIFF
--- a/plugins/TPBDMarkers/TPDBMarkers.yml
+++ b/plugins/TPBDMarkers/TPDBMarkers.yml
@@ -12,6 +12,11 @@ hooks:
     triggeredBy:
       - Scene.Update.Post
 
+settings:
+  disableSceneMarkerHook:
+    displayName: Disable the Scene Markers hook
+    type: BOOLEAN
+
 tasks:
   - name: "Sync"
     description: Get markers for all scenes with a stashid from metadataapi.net and no markers

--- a/plugins/TPBDMarkers/tpdbMarkers.py
+++ b/plugins/TPBDMarkers/tpdbMarkers.py
@@ -95,6 +95,14 @@ json_input = json.loads(sys.stdin.read())
 FRAGMENT_SERVER = json_input["server_connection"]
 stash = StashInterface(FRAGMENT_SERVER)
 
+config = stash.get_configuration()["plugins"]
+settings = {
+    "disableSceneMarkerHook": False,
+}
+if "tPdBmarkers" in config:
+    settings.update(config["tPdBmarkers"])
+log.debug("settings: %s " % (settings,))
+
 # Set up the auth token for tpdb
 if "https://metadataapi.net/graphql" in [
     x["endpoint"] for x in stash.get_configuration()["general"]["stashBoxes"]
@@ -108,10 +116,11 @@ if "https://metadataapi.net/graphql" in [
         if "processScene" in PLUGIN_ARGS:
             processAll()
     elif "hookContext" in json_input["args"]:
-        id = json_input["args"]["hookContext"]["id"]
-        if json_input["args"]["hookContext"]["type"] == "Scene.Update.Post":
-            scene = stash.find_scene(id)
-            processScene(scene)
+        _id = json_input["args"]["hookContext"]["id"]
+        _type = json_input["args"]["hookContext"]["type"]
+        if _type == "Scene.Update.Post" and not settings["disableSceneMarkerHook"]:
+                scene = stash.find_scene(_id)
+                processScene(scene)
 
 else:
     log.warning("The Porn DB endpoint not configured")

--- a/plugins/timestampTrade/timestampTrade.py
+++ b/plugins/timestampTrade/timestampTrade.py
@@ -656,10 +656,12 @@ settings = {
     "createGalleryFromScene": False,
     "createMovieFromScene": False,
     "extraUrls": False,
+    "disableSceneMarkersHook": False,
+    "disableGalleryLookupHook": False,
 }
 if "timestampTrade" in config:
     settings.update(config["timestampTrade"])
-log.debug("config: %s " % (settings,))
+log.debug("settings: %s " % (settings,))
 
 
 if "mode" in json_input["args"]:
@@ -700,10 +702,11 @@ if "mode" in json_input["args"]:
         processAll()
 
 elif "hookContext" in json_input["args"]:
-    id = json_input["args"]["hookContext"]["id"]
-    if json_input["args"]["hookContext"]["type"] == "Scene.Update.Post":
-        scene = stash.find_scene(id)
+    _id = json_input["args"]["hookContext"]["id"]
+    _type = json_input["args"]["hookContext"]["type"]
+    if _type == "Scene.Update.Post" and not settings["disableSceneMarkersHook"]:
+        scene = stash.find_scene(_id)
         processScene(scene)
-    if json_input["args"]["hookContext"]["type"] == "Gallery.Update.Post":
-        gallery = stash.find_gallery(id)
+    if _type == "Gallery.Update.Post" and not settings["disableGalleryLookupHook"]:
+        gallery = stash.find_gallery(_id)
         processGallery(gallery)

--- a/plugins/timestampTrade/timestampTrade.yml
+++ b/plugins/timestampTrade/timestampTrade.yml
@@ -19,6 +19,12 @@ settings:
     displayName: Add extra urls if they exist on timestamp.trade
     description: Extra urls can be submitted to timestamp.trade, add them to the scene if they exist
     type: BOOLEAN
+  disableSceneMarkersHook:
+    displayName: Disable the Scene Markers hook
+    type: BOOLEAN
+  disableGalleryLookupHook:
+    displayName: Disable the Gallery Lookup hook
+    type: BOOLEAN
 
 hooks:
   - name: Add Marker to Scene


### PR DESCRIPTION
I add settings to two scene marker plugins. Hooks can be disabled by user without disabling whole plugin. This way tasks remain active and can be called when needed.