### PR TITLE
[renamerOnUpdate] Untrack custom config and load it first if present

### DIFF
--- a/plugins/renamerOnUpdate/.gitignore
+++ b/plugins/renamerOnUpdate/.gitignore
@@ -1,0 +1,1 @@
+config.py

--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -27,9 +27,10 @@ except Exception:
 
 
 try:
-    import renamerOnUpdate_config as config
-except Exception:
     import config
+except Exception:
+    print("Could not import ROU config file did you rename the template file to 'config.py'?",file=sys.stderr)
+    
 import log
 
 

--- a/plugins/renamerOnUpdate/renamerOnUpdate.py
+++ b/plugins/renamerOnUpdate/renamerOnUpdate.py
@@ -25,13 +25,13 @@ try:
 except Exception:
     MODULE_UNIDECODE = False
 
+import log
 
 try:
     import config
 except Exception:
-    print("Could not import ROU config file did you rename the template file to 'config.py'?",file=sys.stderr)
-    
-import log
+    log.LogWarning("Could not import ROU config file, did you rename the template file to 'config.py'? Defaulting to template config file",file=sys.stderr)
+    import renamerOnUpdate_config as config
 
 
 DB_VERSION_FILE_REFACTOR = 32


### PR DESCRIPTION
don't track the customized config file for ROU so on update changes to the config are not squashed

The current preference is for the plugin to use the template before the custom config file, this inverts that and will first attempt to load the custom config before the template