### PR TITLE
[defaultDataForPath] fix GRAPHQL_VALIDATION_FAILED on scene post

### DIFF
--- a/plugins/defaultDataForPath/defaultDataForPath.js
+++ b/plugins/defaultDataForPath/defaultDataForPath.js
@@ -158,7 +158,9 @@ function getScenePath(ID) {
     "\
 query findScene($id: ID) {\
     findScene(id: $id) {\
-        path\
+        files {\
+            path\
+        }\
     }\
 }";
 
@@ -172,7 +174,7 @@ query findScene($id: ID) {\
     return null;
   }
 
-  var path = findScene.path;
+  var path = findScene.files[0].path;
   return path;
 }
 


### PR DESCRIPTION
Fix error : 
```
Scene.Create.Post [Default Data For Path]: returned error: Error: graphQL query failed: 422 - {"errors":[{"message":"Cannot query field \"path\" on type \"Scene\". Did you mean \"paths\" or \"date\"?","locations":[{"line":1,"column":59}],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}. Query: query findScene($id: ID) {    findScene(id: $id) {        path    }}. Variables: map[id:13785]
```