### PR TITLE
VideoScrollWheel: Add new option for volume change

### DIFF
--- a/plugins/VideoScrollWheel/VideoScrollWheel.yml
+++ b/plugins/VideoScrollWheel/VideoScrollWheel.yml
@@ -1,7 +1,11 @@
 name: VideoScrollWheel
 description: Adds functionality to change volume/time in scene video player by hovering over left/right side of player and scrolling with mouse scrollwheel. Scroll while hovering on left side to adjust volume, scroll on right side to skip forward/back.
-version: 0.1
+version: 0.2
 settings:
+  allowVolumeChange:
+    displayName: Volume change via mouse wheel
+    description: Allow volume to be changed via mouse wheel. When disabled it always changes video position.
+    type: BOOLEAN
   volumeScrollSpeed:
     displayName: Volume Scroll Speed
     description: (Default=100.0) Scales the amount of change in volume per mouse wheel click. Negative value reverses scroll direction.

--- a/plugins/VideoScrollWheel/videoScrollWheel.js
+++ b/plugins/VideoScrollWheel/videoScrollWheel.js
@@ -47,7 +47,7 @@
 
     var scrollDelta = e.deltaY;
 
-    if ((targetWidth / 2 > targetX) && pluginSettings.allowVolumeChange)  {
+    if (targetWidth / 2 > targetX && pluginSettings.allowVolumeChange) {
       // Scrolled on left side, change volume.
       var newVolume =
         vjsPlayer.volume() +

--- a/plugins/VideoScrollWheel/videoScrollWheel.js
+++ b/plugins/VideoScrollWheel/videoScrollWheel.js
@@ -12,7 +12,7 @@
   let scrollVelocity = 1;
   let previousTime = Date.now();
   let pluginSettings = {
-	allowVolumeChange: false,
+    allowVolumeChange: false,
     volumeScrollSpeed: 100.0,
     timeScrollSpeed: 100.0,
     timeScrollAcceleration: 100.0,

--- a/plugins/VideoScrollWheel/videoScrollWheel.js
+++ b/plugins/VideoScrollWheel/videoScrollWheel.js
@@ -12,6 +12,7 @@
   let scrollVelocity = 1;
   let previousTime = Date.now();
   let pluginSettings = {
+	allowVolumeChange: false,
     volumeScrollSpeed: 100.0,
     timeScrollSpeed: 100.0,
     timeScrollAcceleration: 100.0,
@@ -46,7 +47,7 @@
 
     var scrollDelta = e.deltaY;
 
-    if (targetWidth / 2 > targetX) {
+    if ((targetWidth / 2 > targetX) && pluginSettings.allowVolumeChange)  {
       // Scrolled on left side, change volume.
       var newVolume =
         vjsPlayer.volume() +


### PR DESCRIPTION
allowVolumeChange to let the user decide if volume changing via mouse wheel is enabled. Blocks accidental volume changes.