### PR TITLE
fix: total page count skipping last page

### DIFF
--- a/plugins/TPBDMarkers/tpdbMarkers.py
+++ b/plugins/TPBDMarkers/tpdbMarkers.py
@@ -5,6 +5,7 @@ import sys
 import requests
 import json
 import time
+import math
 
 
 per_page = 100
@@ -63,7 +64,7 @@ def processAll():
     )[0]
     log.info(str(count) + " scenes to submit.")
     i = 0
-    for r in range(1, int(count / per_page) + 1):
+    for r in range(1, math.ceil(count / per_page) + 1):
         log.info(
             "fetching data: %s - %s %0.1f%%"
             % (

--- a/plugins/timestampTrade/timestampTrade.py
+++ b/plugins/timestampTrade/timestampTrade.py
@@ -207,7 +207,7 @@ def processAll():
     )[0]
     log.info(str(count) + " scenes to submit.")
     i = 0
-    for r in range(1, int(count / per_page) + 1):
+    for r in range(1, math.ceil(count / per_page) + 1):
         log.info(
             "fetching data: %s - %s %0.1f%%"
             % (


### PR DESCRIPTION
`int` is rounding down floats causing the last page to be skipped (or not run at all if only one page).
Using `ceil` method to round up effectively takes that forgotten page into account.

Edited TPDBMarkers and timestamp.trade