### PR TITLE
[PDT] fix compare_encoding return value

### DIFF
--- a/plugins/phashDuplicateTagger/config_example.py
+++ b/plugins/phashDuplicateTagger/config_example.py
@@ -145,7 +145,7 @@ def compare_encoding(self, other):
         worse, better = self, other
     worse.remove_reason = "video_codec"
     return (
-        self,
+        better,
         f"Prefer Codec {better.codec}({better.id}) over {worse.codec}({worse.id})",
     )
 

--- a/plugins/phashDuplicateTagger/phashDuplicateTagger.yml
+++ b/plugins/phashDuplicateTagger/phashDuplicateTagger.yml
@@ -1,6 +1,6 @@
 name: "PHash Duplicate Tagger"
 description: Will tag scenes based on duplicate PHashes for easier/safer removal.
-version: 0.1.3
+version: 0.1.4
 url: https://github.com/stashapp/CommunityScripts/tree/main/plugins/phashDuplicateTagger
 exec:
   - python


### PR DESCRIPTION
The "self" scene was always returned meaning it would always be tagged as the scene to keep.
Return the better scene object as per the expected behaviour.