### PR TITLE
Fix URL bug, bump to 1.0

### DIFF
--- a/plugins/discordPresence/README.md
+++ b/plugins/discordPresence/README.md
@@ -1,11 +1,11 @@
-# Presence
+# Discord Presence
 
-A plugin which shows the metadata of the currently playing scene as your Discord presence
+A plugin which shows the metadata of the currently playing Stash scene as your Discord presence
 
 ## Setup
 ### Prerequisites to get the plugin working
 - Download and run [Discord RPC Server](https://github.com/lolamtisch/Discord-RPC-Extension/releases). You **do not** need any browser extensions.
-- Install [`StashUserscriptLibrary`](https://github.com/stashapp/CommunityScripts/tree/main/plugins/stashUserscriptLibrary) from your Stash plugin menu (if you don't already have it)
+- Install [`StashUserscriptLibrary`](https://github.com/stashapp/CommunityScripts/tree/main/plugins/stashUserscriptLibrary) from your Stash plugin menu.
 
 #### Why the desktop app?
 <sub>
@@ -15,16 +15,16 @@ This plugin relies on a separate desktop app (Discord RPC Server) running in the
 ## Configuration
 You can customize almost any part of the activity presence with the plugin options.
 
-| Presence element      | Default value (if empty; reverts to: )  | Plugin setting name           | Configuration |
-| --------------------- | --------------------------------------- | ----------------------------- | ------------- |
-| Activity name         | `1236860180407521341` (displays "Stash") | Custom Discord application ID | Create a new application under your [Discord developer portal](https://discord.com/developers/applications). <sub>The name of the application will be the name of the activity being shown as "Playing". Copy the `APPLICATION ID` (20 digit number) from the Developer Portal, and set it in the plugin options.</sub> |
-| Details (first line)  | `{title}`                           | Presence details text         | Custom text and variables |
-| State (second line)   | `from {studio_name}`                     | Presence state text           | Custom text and variables |
-| Show activity image   | Off                                     | Show presence image           | Toggle switch |
-| Custom activity image | `stashbox`                              | Custom presence image key     | After creating a Discord app (see first config option), go to your application settings > Rich Presence > Art Assets. Upload your custom image, give it a key name, and put this in the plugin option (takes a short while for the asset to appear after uploading). |
-| Activity hover text   | Empty                                   | Custom image text             | Custom text and variables |
-| Show URL button       | Off                                     | Show scene URL button         | Toggle switch |
-| Custom button text    | `Watch`                                 | Custom button text            | Custom text and variables |
+| Presence element      | Plugin setting name           | Default value (if empty; reverts to: )   | Configuration                                                                                                                                                                                                                                                                                                          |
+|-----------------------|-------------------------------|------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Activity name         | Custom Discord application ID | `1236860180407521341` (displays "Stash") | Create a new application under your [Discord developer portal](https://discord.com/developers/applications). <sub>The name of the application will be the name of the activity being shown as "Playing". Copy the `APPLICATION ID` (20 digit number) from the Developer Portal and set it in the plugin options.</sub> |
+| Details (first line)  | Presence details text         | `{title}`                                | Custom text and variables                                                                                                                                                                                                                                                                                              |
+| State (second line)   | Presence state text           | `from {studio_name}`                     | Custom text and variables                                                                                                                                                                                                                                                                                              |
+| Show activity image   | Show presence image           | Off                                      | Toggle switch                                                                                                                                                                                                                                                                                                          |
+| Custom activity image | Custom presence image key     | `stashbox`                               | After creating a Discord app (see first config option) go to your application settings > Rich Presence > Art Assets. Upload your custom image, give it a key name, and put this in the plugin option (takes a short while for the asset to appear after uploading).                                                    |
+| Activity hover text   | Custom image text             | Empty                                    | Custom text and variables                                                                                                                                                                                                                                                                                              |
+| Show URL button       | Show scene URL button         | Off                                      | Toggle switch                                                                                                                                                                                                                                                                                                          |
+| Custom button text    | Custom button text            | `Watch`                                  | Custom text and variables                                                                                                                                                                                                                                                                                              |
 
 ## String variables
 You can insert metadata from the currently playing scene into configurable elements, by enclosing variables in curly braces.

--- a/plugins/discordPresence/discordPresence.js
+++ b/plugins/discordPresence/discordPresence.js
@@ -216,14 +216,15 @@
           : undefined,
         largeImageText: replaceVars(CONFIG.discordLargeImageText, sceneData),
         endTimestamp: sceneData.file_duration > 0 ? endTimestamp : undefined,
-        buttons: CONFIG.discordShowUrlButton
-          ? [
-              {
-                label: replaceVars(CONFIG.discordUrlButtonText, sceneData),
-                url: sceneData.url,
-              },
-            ]
-          : undefined,
+        buttons:
+          CONFIG.discordShowUrlButton && isValidUrl(sceneData.url)
+            ? [
+                {
+                  label: replaceVars(CONFIG.discordUrlButtonText, sceneData),
+                  url: sceneData.url,
+                },
+              ]
+            : undefined,
         instance: true,
       };
     }
@@ -259,5 +260,15 @@
   function replaceVars(templateStr, sceneData) {
     const pattern = /{\s*(\w+?)\s*}/g;
     return templateStr.replace(pattern, (_, token) => sceneData[token] ?? "");
+  }
+
+  function isValidUrl(str) {
+    try {
+      new URL(str);
+    } catch {
+      return false;
+    }
+
+    return true;
   }
 })();

--- a/plugins/discordPresence/discordPresence.yml
+++ b/plugins/discordPresence/discordPresence.yml
@@ -1,39 +1,39 @@
 name: Discord Presence
-description: Sets currently playing scene data as your Discord status. See README for prerequisites and config options (blue link button next to enable/disable button)
+description: Sets currently playing scene data as your Discord status. See README for prerequisites and config options (blue hyperlink next to enable/disable button)
 url: https://github.com/stashapp/CommunityScripts/tree/main/plugins/discordPresence
-version: 0.2
+version: 1.0
 settings:
   discordClientId:
     displayName: Custom Discord application ID
-    description: Set a custom client ID, found here https://discord.com/developers/applications
+    description: Set a custom client ID
     type: STRING
   discordDetailsText:
     displayName: Presence details text
-    description: Formats the first line of your presence.
+    description: Format the first line of your presence text
     type: STRING
   discordStateText:
     displayName: Presence state text
-    description: Formats the second line of your presence.
+    description: Format the second line of your presence text
     type: STRING
   discordShowImage:
     displayName: Show presence image
-    description: Show the large presence image in your Discord profile (shows Stash logo when using default clientId/imageKey)
+    description: Show the large presence activity image
     type: BOOLEAN
   discordLargeImageKey:
     displayName: Custom presence image key
-    description: If using a custom client ID, set a presence image key from https://discord.com/developers/applications/{clientId}/rich-presence/assets
+    description: Set a presence image key (requires custom application ID and art asset, see README)
     type: STRING
   discordLargeImageText:
     displayName: Custom image text
-    description: The text which is shown if a user hover over the activity image (leave blank to disable)
+    description: Format the hover text for the activity image
     type: STRING
   discordShowUrlButton:
     displayName: Show scene URL button
-    description: Show a presence button which links to first scene URL
+    description: Show a presence button which links to the first scene URL
     type: BOOLEAN
   discordUrlButtonText:
     displayName: Custom button text
-    description: Set the displayed text for the presence button (default; "Watch")
+    description: Format the text for the presence button
     type: STRING
 ui:
   requires:


### PR DESCRIPTION
Found an edge case bug where sending malformed URLs would lock up the RPC server and/or the Discord client and freeze the displayed presence. Also changed some README table column ordering and bumped plugin version to 1.0 as this is pretty much as feature-rich as it's going get.