### PR TITLE
use relative path for assets

### DIFF
--- a/plugins/qxSceneCard/qxSceneCard.css
+++ b/plugins/qxSceneCard/qxSceneCard.css
@@ -3,29 +3,28 @@
   font-style: normal;
   font-weight: 100;
   font-display: swap;
-  src: url("/plugin/qxSceneCard/assets/fonts/Inter-Thin.woff2") format("woff2");
+  src: url("./assets/fonts/Inter-Thin.woff2") format("woff2");
 }
 @font-face {
   font-family: "Inter";
   font-style: normal;
   font-weight: 300;
   font-display: swap;
-  src: url("/plugin/qxSceneCard/assets/fonts/Inter-Light.woff2") format("woff2");
+  src: url("./assets/fonts/Inter-Light.woff2") format("woff2");
 }
 @font-face {
   font-family: "Inter";
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url("/plugin/qxSceneCard/assets/fonts/Inter-Regular.woff2")
-    format("woff2");
+  src: url("./assets/fonts/Inter-Regular.woff2") format("woff2");
 }
 @font-face {
   font-family: "Inter";
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url("/plugin/qxSceneCard/assets/fonts/Inter-Bold.woff2") format("woff2");
+  src: url("./assets/fonts/Inter-Bold.woff2") format("woff2");
 }
 .scene-card {
   font-family: "Inter", sans-serif;


### PR DESCRIPTION
- reverse proxy basepath agnostic
- plugin name agnostic

This sets assets to already be at `/plugin/{ID}/`

> Relative URLs, if used, are relative to the URL of the stylesheet (not to the URL of the web page).

https://developer.mozilla.org/en-US/docs/Web/CSS/url