### PR TITLE
rewrite marker grouping algo, use pluginDir

### DIFF
--- a/plugins/AITagger/tag_mappings.csv
+++ b/plugins/AITagger/tag_mappings.csv
@@ -1,37 +1,37 @@
 ServerTag,StashTag,MinDuration,MaxGap,RequiredDuration
-69,69_AI,5,1,20%
-Anal Fucking,Anal Fucking_AI,5,1,30s
-Ass Licking,Ass Licking_AI,5,1,30s
-Ass Penetration,Ass Penetration_AI,5,1,30s
-Ball Licking/Sucking,Ball Licking/Sucking_AI,2,1,20s
-Blowjob,Blowjob_AI,5,1,30s
-Cum on Person,Cum on Person_AI,3,1,15s
-Cum Swapping,Cum Swapping_AI,2,1,15s
-Cumshot,Cumshot_AI,1,1,10s
-Deepthroat,Deepthroat_AI,1,1,30s
-Double Penetration,Double Penetration_AI,5,1,30s
-Fingering,Fingering_AI,5,1,30s
-Fisting,Fisting_AI,3,1,30s
-Footjob,Footjob_AI,3,1,30s
-Gangbang,Gangbang_AI,5,1,30s
-Gloryhole,Gloryhole_AI,5,1,30s
-Grabbing Ass,Grabbing Ass_AI,5,1,30s
-Grabbing Boobs,Grabbing Boobs_AI,5,1,30s
-Grabbing Hair/Head,Grabbing Hair/Head_AI,5,1,30s
-Handjob,Handjob_AI,5,1,30s
-Kissing,Kissing_AI,5,1,30s
-Licking Penis,Licking Penis_AI,2,1,30s
-Masturbation,Masturbation_AI,5,1,30s
-Pissing,Pissing_AI,2,1,30s
-Pussy Licking (Clearly Visible),Pussy Licking (Clearly Visible)_AI,5,1,30s
-Pussy Licking,Pussy Licking_AI,3,1,30s
-Pussy Rubbing,Pussy Rubbing_AI,5,1,30s
-Sucking Fingers,Sucking Fingers_AI,1,1,30s
-Sucking Toy/Dildo,Sucking Toy/Dildo_AI,1,1,30s
-Wet (Genitals),Wet (Genitals)_AI,3,1,30s
-Titjob,Titjob_AI,5,1,30s
-Tribbing/Scissoring,Tribbing/Scissoring_AI,3,1,30s
-Undressing,Undressing_AI,3,1,30s
-Vaginal Penetration,Vaginal Penetration_AI,5,1,30s
-Vaginal Fucking,Vaginal Fucking_AI,5,1,30s
-Vibrating,Vibrating_AI,5,1,30s
+69,69_AI,5,2,20%
+Anal Fucking,Anal Fucking_AI,5,2,30s
+Ass Licking,Ass Licking_AI,5,2,30s
+Ass Penetration,Ass Penetration_AI,5,2,30s
+Ball Licking/Sucking,Ball Licking/Sucking_AI,2,2,20s
+Blowjob,Blowjob_AI,5,2,30s
+Cum on Person,Cum on Person_AI,3,2,15s
+Cum Swapping,Cum Swapping_AI,2,2,15s
+Cumshot,Cumshot_AI,2,1,10s
+Deepthroat,Deepthroat_AI,2,1,30s
+Double Penetration,Double Penetration_AI,5,2,30s
+Fingering,Fingering_AI,5,2,30s
+Fisting,Fisting_AI,3,2,30s
+Footjob,Footjob_AI,3,2,30s
+Gangbang,Gangbang_AI,5,2,30s
+Gloryhole,Gloryhole_AI,5,2,30s
+Grabbing Ass,Grabbing Ass_AI,5,2,30s
+Grabbing Boobs,Grabbing Boobs_AI,5,2,30s
+Grabbing Hair/Head,Grabbing Hair/Head_AI,5,2,30s
+Handjob,Handjob_AI,5,2,30s
+Kissing,Kissing_AI,5,2,30s
+Licking Penis,Licking Penis_AI,2,2,30s
+Masturbation,Masturbation_AI,5,2,30s
+Pissing,Pissing_AI,2,2,30s
+Pussy Licking (Clearly Visible),Pussy Licking (Clearly Visible)_AI,5,2,30s
+Pussy Licking,Pussy Licking_AI,3,2,30s
+Pussy Rubbing,Pussy Rubbing_AI,5,2,30s
+Sucking Fingers,Sucking Fingers_AI,2,1,30s
+Sucking Toy/Dildo,Sucking Toy/Dildo_AI,2,1,30s
+Wet (Genitals),Wet (Genitals)_AI,3,2,30s
+Titjob,Titjob_AI,5,2,30s
+Tribbing/Scissoring,Tribbing/Scissoring_AI,3,2,30s
+Undressing,Undressing_AI,3,2,30s
+Vaginal Penetration,Vaginal Penetration_AI,5,2,30s
+Vaginal Fucking,Vaginal Fucking_AI,5,2,30s
+Vibrating,Vibrating_AI,5,2,30s


### PR DESCRIPTION
requesting review from @skier233

- bump MaxGap to 2 since model seems to generate at intervals of 2

## rewrote marker tagging algorithm
When I was trying out the plugin, I could never get any tags to appear since for some reason they would only have a duration of 0s

Instead of walking through it and searching backwards per marker, this instead searches forwards.

This new sorting algorithm walks through all of the marked timestamps, per tag and continues until the 2s gap is exceeded or it reaches the end. If the gap is exceeded, that marker is closed off and the next one started unless it exceeds the number of timestamps left. Some variables were also renamed in order to more clearly reflect their purpose