### PR TITLE
Update defaultDataForPath.js to work with possible updated hookContext

### DIFF
--- a/plugins/defaultDataForPath/defaultDataForPath.js
+++ b/plugins/defaultDataForPath/defaultDataForPath.js
@@ -19,7 +19,7 @@ function ok() {
 function main() {
   var hookContext = input.Args.hookContext;
   var type = hookContext.type;
-  var ID = hookContext.ID;
+  var ID = hookContext.id;
 
   if (!type || !ID) {
     // just return


### PR DESCRIPTION
input.Args.hookContext object attribute `ID` seems to have been renamed to `id`