### PR TITLE
Updating misc-tags to add more group makeup options for foursome, fivesome, sixsome, sevensome.

### DIFF
--- a/plugins/miscTags/miscTags.py
+++ b/plugins/miscTags/miscTags.py
@@ -29,7 +29,7 @@ VRCTags = {
     "180_lr": {"VRCTags": ["DOME", "SBS"], "projTags": ["180°"]},
     "180_3dh_lr": {"VRCTags": ["DOME", "SBS"], "projTags": ["180°"]},
     "360_tb": {"VRCTags": ["SPHERE", "TB"], "projTags": ["360°"]},
-    "mkx200": {"VRCTags": ["MKX200", "FISHEYE", "SBS"], "projTags": ["220°"]},
+    "mkx200": {"VRCTags": ["MKX200", "FISHEYE", "SBS"], "projTags": ["200°"]},
     "mkx220": {"VRCTags": ["MKX220", "FISHEYE", "SBS"], "projTags": ["220°"]},
     "vrca220": {"VRCTags": ["VRCA220", "FISHEYE", "SBS"], "projTags": ["220°"]},
     "rf52": {"VRCTags": ["RF52", "FISHEYE", "SBS"], "projTags": ["190°"]},
@@ -58,7 +58,7 @@ def processScene(scene):
         if settings["addVRTags"]:
             processVRTags(scene, tags)
         if settings["addSoloTags"]:
-            soloTag(scene,tags)
+            soloTag(scene, tags)
         if settings["addThreesomeTags"]:
             processGroupMakeup(['threesome'], 'Threesome', 3, scene, tags)
         if settings["addFoursomeTags"]:

--- a/plugins/miscTags/miscTags.yml
+++ b/plugins/miscTags/miscTags.yml
@@ -1,6 +1,6 @@
 name: Misc Tags
 description: Add extra tags for VR and other ues
-version: 0.3
+version: 0.4
 url: https://github.com/stashapp/CommunityScripts/
 exec:
   - python
@@ -15,13 +15,33 @@ settings:
     displayName: Add VR related tags
     description: Add projection based tags 180°, 200°, VR
     type: BOOLEAN
-  addVSoloTags:
+  addSoloTags:
     displayName: Add solo tags
     description: if there is the "solo" tag and 1 performer add the "Solo Female" tag
     type: BOOLEAN
-  addVThreesomeTags:
-    displayName: Add threesome tags
+  addThreesomeTags:
+    displayName: Add threesome (xxx)
     description: if there is the "threesome" tag with 3 tagged performers add a group makeup tag eg Threesome (BGG)
+    type: BOOLEAN
+  addFoursomeTags:
+    displayName: Add Foursome (XXXX)
+    description: if there is the "foursome" tag with 4 tagged performers add a group makeup tag eg Threesome (BGG)
+    type: BOOLEAN
+  addFivesomeTags:
+    displayName: Add Fivesome (xxxxx) tags
+    description: if there is the "fivesome" tag with 5 tagged performers add a group makeup tag eg Threesome (BGG)
+    type: BOOLEAN
+  addSixsomeTags:
+    displayName: Add Sixsome (XXXXXX)
+    description: if there is the "sixsome" tag with 6 tagged performers add a group makeup tag eg Threesome (BGG)
+    type: BOOLEAN
+  addSevensomeTags:
+    displayName: Add Sevensome (XXXXXXX)
+    description: if there is the "sevensome" tag with 7 tagged performers add a group makeup tag eg Threesome (BGG)
+    type: BOOLEAN
+  assumeMissingMale:
+    displayName: Assume missing male performer
+    description: For the group makeup tag assume the missing performer is male if there are unknown performers
     type: BOOLEAN
 
   flatStudio:


### PR DESCRIPTION
This should expand the group makeup tags so if there is the foursome tags and you have 3 female performers and one male it will add the tag "Foursome (BGGG)".
For sites that do not include the male there is a setting to assume they are male so a "Fivesome" with 3 female performers added to the scene will end up with the "Fivesome (BBGGG)" tag.
If there are missing performers and this setting is turned off there are unknown performers and no group makeup tag will be added.