### PR TITLE
fix requires syntax

### DIFF
--- a/plugins/VideoScrollWheel/VideoScrollWheel.yml
+++ b/plugins/VideoScrollWheel/VideoScrollWheel.yml
@@ -1,6 +1,6 @@
 name: VideoScrollWheel
+# requires: CommunityScriptsUILibrary
 description: Adds functionality to change volume/time in scene video player by hovering over left/right side of player and scrolling with mouse scrollwheel. Scroll while hovering on left side to adjust volume, scroll on right side to skip forward/back.
-#requires: CommunityScriptsUILibrary
 version: 0.2
 settings:
   allowVolumeChange:

--- a/plugins/discordPresence/discordPresence.yml
+++ b/plugins/discordPresence/discordPresence.yml
@@ -1,7 +1,7 @@
 name: Discord Presence
 description: Sets currently playing scene data as your Discord status. See README for prerequisites and config options (blue hyperlink next to enable/disable button)
 url: https://github.com/stashapp/CommunityScripts/tree/main/plugins/discordPresence
-#requires: CommunityScriptsUILibrary
+# requires: CommunityScriptsUILibrary
 version: 1.0
 settings:
   discordClientId:

--- a/plugins/stats/stats.yml
+++ b/plugins/stats/stats.yml
@@ -1,5 +1,5 @@
 name: Extended Stats
-#requires: CommunityScriptsUILibrary
+# requires: CommunityScriptsUILibrary
 description: Adds new stats to the stats page
 version: 1.1
 ui:


### PR DESCRIPTION
`#requires:` specifically needs a space - these packages were parsed without the csUiLib requirement