### PR TITLE
[Hot Cards] Add card_opts as new optional parameter

### DIFF
--- a/plugins/hotCards/README.md
+++ b/plugins/hotCards/README.md
@@ -22,17 +22,18 @@ After installation, you can configure the plugin to suit your needs. Set a desir
 
 ### Configure the field format:
 
-_[criterion]\_[value]\_[style]\_[gradient-opts]\_[border-opts]_
+_[criterion]\_[value]\_[style]\_[gradient-opts]\_[hover-opts]\_[card-opts]_
 
 **Important**: If you have previously installed the plugin, after updating to `1.1.0`, be sure to update your settings from the old boolean format to the new string format. Refresh the page for the changes to take effect.
 
-| Parameter         | Description                                                                                                                                                                                                                                                                                      |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `<criterion>`     | Defines the basis for applying styles. Use `t` for tag-based criteria, `r` for rating-based criteria, or `d` to disable. If left empty, it will default to the global Tag ID or Rating Threshold configuration. If both options are enabled and unspecified, the Tag ID will be used by default. |
-| `<value>`         | Specifies the exact value for the Tag ID or Rating Threshold to be used.                                                                                                                                                                                                                         |
-| `<style>`         | Defines the styling options as a comma-separated list of colors or presets. Options include: a fixed color (e.g., #5ff2a2), a style preset (e.g., hot), or a gradient (e.g., #ef1313,#3bd612,... with hex color codes or color names).                                                           |
-| `<gradient-opts>` | Specifies gradient options as a comma-separated list: `<gradient type>,<gradient angle>,<gradient animation>`. Example: **linear,35deg,4s alternate infinite** for a linear gradient with a 35-degree angle and a 4-second alternating infinite animation.                                       |
-| `<border-opts>`   | Specifies border options as a comma-separated list: `<border color>,<border animation>`. Example: **#ff0000,2s ease infinite** for a border with a color of #ff0000 and a 2-second ease infinite animation.                                                                                      |
+| Parameter         | Description                                                                                                                                                                                                                               | Details                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `<criterion>`     | Defines the basis for applying styles. Use `t` for tag-based criteria, `r` for rating-based criteria, or `d` to disable.                                                                                                                  | If left empty, it will default to the global **Tag ID** or **Rating Threshold** configuration. If both options are enabled and unspecified, the Tag ID will be used by default.                                                                                                                                                                                                                                                                                                                     |
+| `<value>`         | Specifies the exact value for the Tag ID or Rating Threshold to be used.                                                                                                                                                                  |
+| `<style>`         | Defines the styling options as a comma-separated list of colors or presets. Options include: a fixed color (e.g., #5ff2a2), a Style Preset (e.g., hot), or a gradient (e.g., #ef1313,#3bd612,... with hex color codes or color names).    | Defaults to **default** (basic style preset)<br><br>Style Presets available: **default**, **hot**, **gold**.                                                                                                                                                                                                                                                                                                                                                                                        |
+| `<gradient_opts>` | Specifies gradient options as a comma-separated list: `<type>,<angle>,<animation>`.</br></br> Example: **linear,35deg,4s alternate infinite** for a linear gradient with a 35-degree angle and a 4-second alternating infinite animation. | `<type>` Defaults to **linear**</br></br>Refer to [Using CSS gradients](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_images/Using_CSS_gradients) to see all types you can use.</br></br>`<angle>` Defaults to **0deg**</br></br>`<animation>` Defaults to **none**</br></br>Note that you can only configure the animation properties of the element. See [Using CSS animations](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_animations/Using_CSS_animations) for additional info. |
+| `<hover_opts>`    | Specifies hover options as a comma-separated list: `<color>,<animation>`.</br></br>Example: **#ff0000,2s ease infinite** for a hover effect with a color of #ff0000 and a 2-second ease infinite animation.                               | `<color>` Defaults to **transparent**</br></br>`<animation>` Defaults to **none**</br></br>Similar to the gradient animation, you can only configure the animation properties of the element.                                                                                                                                                                                                                                                                                                       |
+| `<card_opts>`     | Specifies the general options for the card as a comma-separated list: `<fill>,<opacity>`.                                                                                                                                                 | `fill` Defaults to **true**<br>_Indicates whether the card should be filled._</br></br>Tip: You can set this to **false** to color only the border of the card.</br></br>`opacity` Defaults to **80**<br>_Represents the opacity for the card background. Range from 0 to 100._                                                                                                                                                                                                                     |
 
 <br />
 
@@ -44,13 +45,14 @@ _[criterion]\_[value]\_[style]\_[gradient-opts]\_[border-opts]_
 
 `t_123_gold`
 
-| Segment       | Value | Meaning           |
-| ------------- | ----- | ----------------- |
-| criterion     | t     | Tag-based         |
-| value         | 123   | Use 123 as Tag ID |
-| style         | gold  | Use Gold preset   |
-| gradient-opts |       | No gradient       |
-| border-opts   |       | No border         |
+| Segment       | Value | Meaning            |
+| ------------- | ----- | ------------------ |
+| criterion     | t     | Tag-based          |
+| value         | 123   | Use 123 as Tag ID  |
+| style         | gold  | Use Gold preset    |
+| gradient-opts |       | No gradient        |
+| hover-opts    |       | No hover effect    |
+| card-opts     |       | Use default values |
 
 ---
 
@@ -58,13 +60,14 @@ _[criterion]\_[value]\_[style]\_[gradient-opts]\_[border-opts]_
 
 `__hot_,,none_pink,none`
 
-| Segment       | Value     | Meaning                               |
-| ------------- | --------- | ------------------------------------- |
-| criterion     |           | Use tag or rating as configured       |
-| value         |           | Use tag or rating global value        |
-| style         | hot       | Use Hot preset                        |
-| gradient-opts | ,,none    | No gradient animation                 |
-| border-opts   | pink,none | Set border color, no border animation |
+| Segment       | Value     | Meaning                                    |
+| ------------- | --------- | ------------------------------------------ |
+| criterion     |           | Use tag or rating as configured            |
+| value         |           | Use global tag or rating value             |
+| style         | hot       | Use Hot preset                             |
+| gradient-opts | ,,none    | No gradient animation                      |
+| hover-opts    | pink,none | Set hover effect color, no hover animation |
+| card-opts     |           | Use default values                         |
 
 ---
 
@@ -75,38 +78,56 @@ _[criterion]\_[value]\_[style]\_[gradient-opts]\_[border-opts]_
 | Segment       | Value   | Meaning                 |
 | ------------- | ------- | ----------------------- |
 | criterion     | r       | Rating-based            |
-| value         |         | Use rating global value |
+| value         |         | Use global rating value |
 | style         | #2673b8 | Set fixed color         |
 | gradient-opts |         | No gradient             |
-| border-opts   |         | No border               |
+| hover-opts    |         | No hover effect         |
+| card-opts     |         | Use default values      |
 
 ---
 
-**Fixed Color with Border**
+**Fixed Color border-only**
+
+`r_4_white___false`
+
+| Segment       | Value | Meaning                   |
+| ------------- | ----- | ------------------------- |
+| criterion     | r     | Rating-based              |
+| value         | 4     | Use 4 as Rating Threshold |
+| style         | white | Set fixed color           |
+| gradient-opts |       | No gradient               |
+| hover-opts    |       | No hover effect           |
+| card-opts     | false | No fill                   |
+
+---
+
+**Fixed Color with hover effect**
 
 `__#5ff2a2__#5ff1a1`
 
-| Segment       | Value   | Meaning                              |
-| ------------- | ------- | ------------------------------------ |
-| criterion     |         | Use tag or rating as configured      |
-| value         |         | Use tag or rating global value       |
-| style         | #5ff2a2 | Set fixed color                      |
-| gradient-opts |         | No gradient                          |
-| border-opts   | #5ff1a1 | Set border color when hovering cards |
+| Segment       | Value   | Meaning                         |
+| ------------- | ------- | ------------------------------- |
+| criterion     |         | Use tag or rating as configured |
+| value         |         | Use global tag or rating value  |
+| style         | #5ff2a2 | Set fixed color                 |
+| gradient-opts |         | No gradient                     |
+| hover-opts    | #5ff1a1 | Set hover color                 |
+| card-opts     |         | Use default values              |
 
 ---
 
-**Gradient with Border**
+**Gradient with hover effect**
 
 `_67_pink,red,yellow,green,red,blue_,30deg,5s ease infinite_red,1s ease-in-out infinite`
 
-| Segment       | Value                          | Meaning                              |
-| ------------- | ------------------------------ | ------------------------------------ |
-| criterion     |                                | Use tag or rating as configured      |
-| value         | 67                             | Use 67 as Tag ID or Rating Threshold |
-| style         | pink,red,yellow,green,red,blue | Make gradient                        |
-| gradient-opts | ,30deg,5s ease infinite        | Specify angle and animate gradient   |
-| border-opts   | red,1s ease-in-out infinite    | Set border color and animate border  |
+| Segment       | Value                          | Meaning                                   |
+| ------------- | ------------------------------ | ----------------------------------------- |
+| criterion     |                                | Use tag or rating as configured           |
+| value         | 67                             | Use 67 as Tag ID or Rating Threshold      |
+| style         | pink,red,yellow,green,red,blue | Use gradient                              |
+| gradient-opts | ,30deg,5s ease infinite        | Specify angle, and animate gradient       |
+| hover-opts    | red,1s ease-in-out infinite    | Set hover effect color, and animate hover |
+| card-opts     | ,100                           | Use max opacity                           |
 
 **Note**: _You can also skip inner values, notice the first comma in **gradient-opts**. The type is not provided, so linear gradient will be used by default._
 

--- a/plugins/hotCards/hotCards.css
+++ b/plugins/hotCards/hotCards.css
@@ -5,8 +5,7 @@
   border-radius: var(--border-width);
 }
 
-.hot-card > .card {
-  background-color: rgba(0, 0, 0, 0.2);
+.hot-card > .hot-border {
   height: auto;
 }
 
@@ -16,8 +15,8 @@
 
 .hot-border:hover {
   box-shadow:
-    0px 0px 1em var(--border-color),
-    0px 0px 2em var(--border-color);
+    0px 0px 1em var(--hover-color),
+    0px 0px 2em var(--hover-color);
   animation: none !important;
 }
 
@@ -27,8 +26,8 @@
   }
   70% {
     box-shadow:
-      0px 0px 1em var(--border-color),
-      0px 0px 2em var(--border-color);
+      0px 0px 1em var(--hover-color),
+      0px 0px 2em var(--hover-color);
   }
   100% {
     box-shadow: 0 0 0 0 rgba(255, 36, 9, 0);

--- a/plugins/hotCards/hotCards.js
+++ b/plugins/hotCards/hotCards.js
@@ -13,9 +13,13 @@
       angle: "0deg",
       animation: "",
     },
-    border_opts: {
+    hover_opts: {
       color: "transparent",
       animation: "",
+    },
+    card_opts: {
+      fill: true,
+      opacity: 80,
     },
   };
   const CRITERIA = { tag: "t", rating: "r", disabled: "d" };
@@ -50,6 +54,12 @@
     gold: getGoldStylePreset(),
   };
 
+  /**
+   * Element to inject custom CSS styles.
+   */
+  const styleElement = document.createElement("style");
+  document.head.appendChild(styleElement);
+
   const isTagBased = TAG_ID?.length;
   const isRatingBased = RATING_THRESHOLD !== 0;
   const isTagOrRatingBased = isTagBased || isRatingBased;
@@ -81,9 +91,13 @@
         "angle",
         "animation",
       ]),
-      border_opts: parseSegment(segments[4], DEFAULTS.border_opts, [
+      hover_opts: parseSegment(segments[4], DEFAULTS.hover_opts, [
         "color",
         "animation",
+      ]),
+      card_opts: parseSegment(segments[5], DEFAULTS.card_opts, [
+        "fill",
+        "opacity",
       ]),
     };
   }
@@ -324,35 +338,63 @@
    * Sets the style of the hot card based on the user's configuration.
    */
   function setHotCardStyling(card) {
-    const { style, gradient_opts, border_opts } = card.config;
+    const { style, gradient_opts, hover_opts, card_opts } = card.config;
     const colors = style.split(INNER_SEPARATOR).map((color) => color.trim());
-    const styleElement = document.createElement("style");
 
     const pseudoElementStyle =
       colors.length === 1
-        ? applySingleColorStyle(card, colors[0], gradient_opts, border_opts)
-        : applyCustomGradientStyle(card, colors, gradient_opts, border_opts);
+        ? applySingleColorStyle(
+            card,
+            colors[0],
+            gradient_opts,
+            hover_opts,
+            card_opts
+          )
+        : applyCustomGradientStyle(
+            card,
+            colors,
+            gradient_opts,
+            hover_opts,
+            card_opts
+          );
 
-    styleElement.innerHTML = pseudoElementStyle;
-    document.head.appendChild(styleElement);
+    styleElement.innerHTML += pseudoElementStyle;
   }
 
   /**
    * Apply a single color style, which can be a style preset or a fixed color.
    */
-  function applySingleColorStyle(card, color, gradient_opts, border_opts) {
-    if (STYLES[color])
-      return applyPresetStyle(card, STYLES[color], gradient_opts, border_opts);
-    else return applyFixedColorStyle(card, color, border_opts);
+  function applySingleColorStyle(
+    card,
+    color,
+    gradient_opts,
+    hover_opts,
+    card_opts
+  ) {
+    return STYLES[color]
+      ? applyPresetStyle(
+          card,
+          STYLES[color],
+          gradient_opts,
+          hover_opts,
+          card_opts
+        )
+      : applyFixedColorStyle(card, color, hover_opts, card_opts);
   }
 
   /**
    * Apply a style preset.
    */
-  function applyPresetStyle(card, preset, gradient_opts, border_opts) {
-    const { gradient, border } = preset;
+  function applyPresetStyle(
+    card,
+    preset,
+    gradient_opts,
+    hover_opts,
+    card_opts
+  ) {
+    const { gradient, hover } = preset;
     const { angle, animation } = gradient_opts;
-    const { color: borderColor, animation: borderAnimation } = border_opts;
+    const { color: hoverColor, animation: hoverAnimation } = hover_opts;
 
     // Update gradient options with preset defaults if not provided
     const updatedGradientOpts = {
@@ -361,46 +403,53 @@
       animation: animation || gradient.animation,
     };
 
-    // Update border options with preset defaults if not provided
-    const updatedBorderOpts = {
+    // Update hover options with preset defaults if not provided
+    const updatedHoverOpts = {
       color:
-        borderColor !== DEFAULTS.border_opts.color ? borderColor : border.color,
-      animation: borderAnimation || border.animation,
+        hoverColor !== DEFAULTS.hover_opts.color ? hoverColor : hover.color,
+      animation: hoverAnimation || hover.animation,
     };
 
     return applyCustomGradientStyle(
       card,
       gradient.colors,
       updatedGradientOpts,
-      updatedBorderOpts
+      updatedHoverOpts,
+      card_opts
     );
   }
 
   /**
    * Apply a fixed color style.
    */
-  function applyFixedColorStyle(card, color, border_opts) {
-    setBorder(card, border_opts.color, border_opts.animation);
-    return getHotCardPseudoElementString(card, color);
+  function applyFixedColorStyle(card, color, hover_opts, card_opts) {
+    setHoverStyleProperties(card, hover_opts.color, hover_opts.animation);
+    return getHotCardPseudoElementString(card, card_opts, color);
   }
 
   /**
    * If there are more than one color, it's a custom gradient.
    */
-  function applyCustomGradientStyle(card, colors, gradient_opts, border_opts) {
+  function applyCustomGradientStyle(
+    card,
+    colors,
+    gradient_opts,
+    hover_opts,
+    card_opts
+  ) {
     const { type, angle, animation } = gradient_opts;
     const gradient = getGradient(type, angle, colors);
-    setBorder(card, border_opts.color, border_opts.animation);
-    return getHotCardPseudoElementString(card, gradient, animation);
+    setHoverStyleProperties(card, hover_opts.color, hover_opts.animation);
+    return getHotCardPseudoElementString(card, card_opts, gradient, animation);
   }
 
-  function setBorder(card, color, animation = "") {
-    animation = animation ? `pulse ${animation}` : "";
+  function setHoverStyleProperties(card, color, animation) {
+    const animationStr = animation ? `pulse ${animation}` : "";
     document
       .querySelectorAll(`.hot-${card.class} > .hot-border`)
-      .forEach((card) => {
-        card.style.setProperty("--border-color", color);
-        card.style.animation = animation;
+      .forEach((hotBorderCard) => {
+        hotBorderCard.style.setProperty("--hover-color", color);
+        hotBorderCard.style.animation = animationStr;
       });
   }
 
@@ -411,13 +460,17 @@
 
   function getHotCardPseudoElementString(
     card,
+    card_opts,
     background,
     gradientAnimation = "",
     filter = ""
   ) {
+    const opacity = getBackgroundOpacity(card_opts.opacity);
+    const fill = /true/i.test(card_opts.fill);
     const gradientAnimationStr = gradientAnimation
       ? `animation: move ${gradientAnimation};`
       : "";
+    const fillStr = fill ? `background-color: rgba(0, 0, 0, ${opacity});` : "";
     const filterStr = filter ? `filter: ${filter};` : "";
     const hotCardClass = `.hot-${card.class}`;
 
@@ -435,14 +488,21 @@
         background-position: 0 50%;
         ${gradientAnimationStr}
       }
+      ${hotCardClass} > .hot-border {
+        ${fillStr}
+      }
       ${hotCardClass}::after {
         ${filterStr}
       }`;
   }
 
+  function getBackgroundOpacity(opacity) {
+    return parseFloat((1 - opacity / 100).toFixed(1));
+  }
+
   function createCardStyle(
-    borderColor,
-    borderAnimation,
+    hoverColor,
+    hoverAnimation,
     gradientType,
     gradientAngle,
     gradientColors,
@@ -450,9 +510,9 @@
     filter
   ) {
     return {
-      border: {
-        color: borderColor,
-        animation: borderAnimation,
+      hover: {
+        color: hoverColor,
+        animation: hoverAnimation,
       },
       gradient: {
         type: gradientType,

--- a/plugins/hotCards/hotCards.yml
+++ b/plugins/hotCards/hotCards.yml
@@ -1,6 +1,6 @@
 name: Hot Cards
 description: Adds custom styling to card elements that match a tag ID or a rating threshold.
-version: 1.1.1
+version: 1.1.2
 url: https://github.com/stashapp/CommunityScripts/tree/main/plugins/hotCards
 # requires: CommunityScriptsUILibrary
 ui:
@@ -29,25 +29,25 @@ settings:
     type: BOOLEAN
   scenes:
     displayName: Enable for scenes
-    description: "Empty to enable, type 'd' to disable. Customize: [criterion]_[value]_[style]_[gradient-opts]_[border-opts]. See docs."
+    description: "Empty to enable, 'd' to disable. Customize: [criterion]_[value]_[style]_[grad-opts]_[hover-opts]_[card-opts]. See docs."
     type: STRING
   images:
     displayName: Enable for images
-    description: "Empty to enable, type 'd' to disable. Customize: [criterion]_[value]_[style]_[gradient-opts]_[border-opts]. See docs."
+    description: "Empty to enable, 'd' to disable. Customize: [criterion]_[value]_[style]_[grad-opts]_[hover-opts]_[card-opts]. See docs."
     type: STRING
   movies:
     displayName: Enable for movies
-    description: "Empty to enable, type 'd' to disable. Customize: [criterion]_[value]_[style]_[gradient-opts]_[border-opts]. See docs."
+    description: "Empty to enable, 'd' to disable. Customize: [criterion]_[value]_[style]_[grad-opts]_[hover-opts]_[card-opts]. See docs."
     type: STRING
   galleries:
     displayName: Enable for galleries
-    description: "Empty to enable, type 'd' to disable. Customize: [criterion]_[value]_[style]_[gradient-opts]_[border-opts]. See docs."
+    description: "Empty to enable, 'd' to disable. Customize: [criterion]_[value]_[style]_[grad-opts]_[hover-opts]_[card-opts]. See docs."
     type: STRING
   performers:
     displayName: Enable for performers
-    description: "Empty to enable, type 'd' to disable. Customize: [criterion]_[value]_[style]_[gradient-opts]_[border-opts]. See docs."
+    description: "Empty to enable, 'd' to disable. Customize: [criterion]_[value]_[style]_[grad-opts]_[hover-opts]_[card-opts]. See docs."
     type: STRING
   studios:
     displayName: Enable for studios
-    description: "Empty to enable, type 'd' to disable. Customize: [criterion]_[value]_[style]_[gradient-opts]_[border-opts]. See docs."
+    description: "Empty to enable, 'd' to disable. Customize: [criterion]_[value]_[style]_[grad-opts]_[hover-opts]_[card-opts]. See docs."
     type: STRING


### PR DESCRIPTION
card_opts allows you to specify whether you want the card to be filled or not, and also set the opacity of the card. This addresses the case where the user wants only the border of the card to be colored.

Other changes:
- Adjust README to include the new option and other additions.
- Change misleading param name 'border_opts' to 'hover_opts' in the docs, code and in the configuration file.
- Update version to 1.1.2.