### PR TITLE
[videoScrollWheel] Fix issue where time change could be ignored

### DIFF
--- a/plugins/VideoScrollWheel/VideoScrollWheel.js
+++ b/plugins/VideoScrollWheel/VideoScrollWheel.js
@@ -88,7 +88,21 @@
         scrollVelocity *
         (pluginSettings.timeScrollSpeed / 100.0);
       var newTime = vjsPlayer.currentTime() + timeDelta;
-      vjsPlayer.currentTime(newTime);
+
+      // Make sure that the time delta is big enough that the change is not ignored.
+      var extraDelta = 0;
+
+      if (timeDelta > 0) {
+        while (vjsPlayer.currentTime() < newTime) {
+          vjsPlayer.currentTime(newTime + extraDelta);
+          ++extraDelta;
+        }
+      } else {
+        while (vjsPlayer.currentTime() > newTime) {
+          vjsPlayer.currentTime(newTime - extraDelta);
+          ++extraDelta;
+        }
+      }
     }
   }
 

--- a/plugins/VideoScrollWheel/VideoScrollWheel.yml
+++ b/plugins/VideoScrollWheel/VideoScrollWheel.yml
@@ -1,7 +1,7 @@
 name: VideoScrollWheel
 # requires: CommunityScriptsUILibrary
 description: Adds functionality to change volume/time in scene video player by hovering over left/right side of player and scrolling with mouse scrollwheel. Scroll while hovering on left side to adjust volume, scroll on right side to skip forward/back.
-version: 0.2
+version: 0.3
 settings:
   allowVolumeChange:
     displayName: Volume change via mouse wheel


### PR DESCRIPTION
This fixes an issue where the time change applied may not work if the delta is too small. I've only observed this being an issue while transcoding a video, direct streams do not seem to ever have this problem.