### PR TITLE
[Hot Cards] Add multi-tag and multi-style support

### DIFF
--- a/plugins/hotCards/README.md
+++ b/plugins/hotCards/README.md
@@ -57,7 +57,7 @@ _[criterion]\_[value]\_[style]\_[gradient-opts]\_[hover-opts]\_[card-opts]_
 
 **Modify an existing Style Preset**:
 
-`__hot_,,none_pink,none`
+`__hot_,,none_pink,none_,40`
 
 | Segment       | Value     | Meaning                                    |
 | ------------- | --------- | ------------------------------------------ |

--- a/plugins/hotCards/README.md
+++ b/plugins/hotCards/README.md
@@ -8,6 +8,7 @@ Hot Cards is a Stash CommunityScript plugin designed to enhance your visual expe
 - Enable or disable Hot Cards on various sections like home, scenes, images, movies, galleries, performers, and studios.
 - Specify Hot Cards to be tag-based or rating-based for each card type, as desired.
 - Customizable Hot Cards.
+- Support for multi-tag and multi-style configurations.
 
 ## Installation
 
@@ -24,18 +25,16 @@ After installation, you can configure the plugin to suit your needs. Set a desir
 
 _[criterion]\_[value]\_[style]\_[gradient-opts]\_[hover-opts]\_[card-opts]_
 
-**Important**: If you have previously installed the plugin, after updating to `1.1.0`, be sure to update your settings from the old boolean format to the new string format. Refresh the page for the changes to take effect.
+| Parameter         | Description                                                                                                                                                                                                                                                                                                                                                                       | Details                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `<criterion>`     | Defines the basis for applying styles. Use `t` for tag-based criteria, `r` for rating-based criteria, or `d` to disable.                                                                                                                                                                                                                                                          | If left empty, it will default to the global **Tag ID** or **Rating Threshold** as configured. If both options are enabled and unspecified, ~~the Tag ID will be used by default~~ both criteria will be used.                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `<value>`         | Specifies the exact value for the Tag ID or Rating Threshold to be used.<br><br>_Multiple values can be specified using a comma-separated list and slashes to delimit each set of criteria:_ `<tag_id>,.../<tag_id>,.../...` or `<rating>/<rating>/...`                                                                                                                           | **Regarding multiple values:**<br><br>For Tag IDs, it will apply the corresponding style _(style, gradient_opts, hover_opts, card_opts)_ if **ALL** tags in a set match.<br><br>The tags are prioritized from **left to right**, meaning if it finds a match for a tag list, the corresponding style is applied and subsequent sets are skipped.<br><br>For ratings, the same left-to-right prioritization applies. For instance, `r_4,2_blue` targets cards with exact ratings of 4 or 2. To style ratings >= 4 and >= 2, use `r_4/2_red/blue`. Here, red applies for ratings >= 4, and blue for ratings >= 2 but less than 4. |
+| `<style>`         | Defines the styling options as a comma-separated list of colors or a style preset.</br></br>Options include: a fixed color (e.g., #5ff2a2), a style preset (e.g., hot), or a gradient (e.g., #ef1313,#3bd612,... hex color codes or color names).<br><br>_A style can be specified for each set of values using a slash-separated list:_ `<style>/<style>/...`                    | Defaults to **default** (basic style preset)<br><br>Style Presets available: **default**, **hot**, **gold**.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `<gradient_opts>` | Specifies gradient options as a comma-separated list: `<type>,<angle>,<animation>`.</br></br> Example: **linear,35deg,4s alternate infinite** for a linear gradient with a 35-degree angle and a 4-second alternating infinite animation.</br></br>_Gradient options can be specified for each set of values using a slash-separated list:_ `<gradient_opts>/<gradient_opts>/...` | `<type>` Defaults to **linear**</br></br>Refer to [Using CSS gradients](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_images/Using_CSS_gradients) to see all types you can use.</br></br>`<angle>` Defaults to **0deg**</br></br>`<animation>` Defaults to **none**</br></br>Note that you can only configure the animation properties of the element. See [Using CSS animations](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_animations/Using_CSS_animations) for additional info.                                                                                                                             |
+| `<hover_opts>`    | Specifies hover options as a comma-separated list: `<color>,<animation>`.</br></br>Example: **#ff0000,2s ease infinite** for a hover effect with a color of #ff0000 and a 2-second ease infinite animation.</br></br>_Hover options can be specified for each set of values using a slash-separated list:_ `<hover_opts>/<hover_opts>/...`                                        | `<color>` Defaults to **transparent**</br></br>`<animation>` Defaults to **none**</br></br>Similar to the gradient animation, you can only configure the animation properties of the element.                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| `<card_opts>`     | Specifies the general options for the card as a comma-separated list: `<fill>,<opacity>`.</br></br>_Card options can be specified for each set of values using a slash-separated list:_ `<card_opts>/<card_opts>/...`                                                                                                                                                             | `fill` Defaults to **true**<br>_Indicates whether the card should be filled._</br></br>Tip: You can set this to **false** to color only the border of the card.</br></br>`opacity` Defaults to **80**<br>_Represents the opacity for the card background. Range from 0 to 100._                                                                                                                                                                                                                                                                                                                                                 |
 
-| Parameter         | Description                                                                                                                                                                                                                               | Details                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `<criterion>`     | Defines the basis for applying styles. Use `t` for tag-based criteria, `r` for rating-based criteria, or `d` to disable.                                                                                                                  | If left empty, it will default to the global **Tag ID** or **Rating Threshold** configuration. If both options are enabled and unspecified, the Tag ID will be used by default.                                                                                                                                                                                                                                                                                                                     |
-| `<value>`         | Specifies the exact value for the Tag ID or Rating Threshold to be used.                                                                                                                                                                  |
-| `<style>`         | Defines the styling options as a comma-separated list of colors or presets. Options include: a fixed color (e.g., #5ff2a2), a Style Preset (e.g., hot), or a gradient (e.g., #ef1313,#3bd612,... with hex color codes or color names).    | Defaults to **default** (basic style preset)<br><br>Style Presets available: **default**, **hot**, **gold**.                                                                                                                                                                                                                                                                                                                                                                                        |
-| `<gradient_opts>` | Specifies gradient options as a comma-separated list: `<type>,<angle>,<animation>`.</br></br> Example: **linear,35deg,4s alternate infinite** for a linear gradient with a 35-degree angle and a 4-second alternating infinite animation. | `<type>` Defaults to **linear**</br></br>Refer to [Using CSS gradients](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_images/Using_CSS_gradients) to see all types you can use.</br></br>`<angle>` Defaults to **0deg**</br></br>`<animation>` Defaults to **none**</br></br>Note that you can only configure the animation properties of the element. See [Using CSS animations](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_animations/Using_CSS_animations) for additional info. |
-| `<hover_opts>`    | Specifies hover options as a comma-separated list: `<color>,<animation>`.</br></br>Example: **#ff0000,2s ease infinite** for a hover effect with a color of #ff0000 and a 2-second ease infinite animation.                               | `<color>` Defaults to **transparent**</br></br>`<animation>` Defaults to **none**</br></br>Similar to the gradient animation, you can only configure the animation properties of the element.                                                                                                                                                                                                                                                                                                       |
-| `<card_opts>`     | Specifies the general options for the card as a comma-separated list: `<fill>,<opacity>`.                                                                                                                                                 | `fill` Defaults to **true**<br>_Indicates whether the card should be filled._</br></br>Tip: You can set this to **false** to color only the border of the card.</br></br>`opacity` Defaults to **80**<br>_Represents the opacity for the card background. Range from 0 to 100._                                                                                                                                                                                                                     |
-
-<br />
+<br>
 
 **Note**: _It is recommended to refresh the page once you are done configuring for the changes to take effect and the previous style to be overwritten._
 
@@ -45,14 +44,14 @@ _[criterion]\_[value]\_[style]\_[gradient-opts]\_[hover-opts]\_[card-opts]_
 
 `t_123_gold`
 
-| Segment       | Value | Meaning            |
-| ------------- | ----- | ------------------ |
-| criterion     | t     | Tag-based          |
-| value         | 123   | Use 123 as Tag ID  |
-| style         | gold  | Use Gold preset    |
-| gradient-opts |       | No gradient        |
-| hover-opts    |       | No hover effect    |
-| card-opts     |       | Use default values |
+| Segment       | Value | Meaning                |
+| ------------- | ----- | ---------------------- |
+| criterion     | t     | Tag-based              |
+| value         | 123   | Use 123 as Tag ID      |
+| style         | gold  | Use Gold preset        |
+| gradient-opts |       | Use Gold gradient opts |
+| hover-opts    |       | Use Gold hover opts    |
+| card-opts     |       | Use default values     |
 
 ---
 
@@ -67,7 +66,7 @@ _[criterion]\_[value]\_[style]\_[gradient-opts]\_[hover-opts]\_[card-opts]_
 | style         | hot       | Use Hot preset                             |
 | gradient-opts | ,,none    | No gradient animation                      |
 | hover-opts    | pink,none | Set hover effect color, no hover animation |
-| card-opts     |           | Use default values                         |
+| card-opts     | ,40       | Set opacity to 40                          |
 
 ---
 
@@ -86,50 +85,80 @@ _[criterion]\_[value]\_[style]\_[gradient-opts]\_[hover-opts]\_[card-opts]_
 
 ---
 
-**Fixed Color border-only**
+**Fixed Color border-only with hover effect**
 
-`r_4_white___false`
+`r_4_white__#5ff1a1_false`
 
-| Segment       | Value | Meaning                   |
-| ------------- | ----- | ------------------------- |
-| criterion     | r     | Rating-based              |
-| value         | 4     | Use 4 as Rating Threshold |
-| style         | white | Set fixed color           |
-| gradient-opts |       | No gradient               |
-| hover-opts    |       | No hover effect           |
-| card-opts     | false | No fill                   |
-
----
-
-**Fixed Color with hover effect**
-
-`__#5ff2a2__#5ff1a1`
-
-| Segment       | Value   | Meaning                         |
-| ------------- | ------- | ------------------------------- |
-| criterion     |         | Use tag or rating as configured |
-| value         |         | Use global tag or rating value  |
-| style         | #5ff2a2 | Set fixed color                 |
-| gradient-opts |         | No gradient                     |
-| hover-opts    | #5ff1a1 | Set hover color                 |
-| card-opts     |         | Use default values              |
+| Segment       | Value   | Meaning                   |
+| ------------- | ------- | ------------------------- |
+| criterion     | r       | Rating-based              |
+| value         | 4       | Use 4 as Rating Threshold |
+| style         | white   | Set fixed color           |
+| gradient-opts |         | No gradient               |
+| hover-opts    | #5ff1a1 | Set hover color           |
+| card-opts     | false   | No fill                   |
 
 ---
 
-**Gradient with hover effect**
+**Animated gradient with animated hover effect**
 
-`_67_pink,red,yellow,green,red,blue_,30deg,5s ease infinite_red,1s ease-in-out infinite`
+`_67_pink,red,yellow,green,red,blue_,30deg,5s ease infinite_red,1s ease-in-out infinite_,100`
 
 | Segment       | Value                          | Meaning                                   |
 | ------------- | ------------------------------ | ----------------------------------------- |
 | criterion     |                                | Use tag or rating as configured           |
 | value         | 67                             | Use 67 as Tag ID or Rating Threshold      |
-| style         | pink,red,yellow,green,red,blue | Use gradient                              |
+| style         | pink,red,yellow,green,red,blue | Apply gradient                            |
 | gradient-opts | ,30deg,5s ease infinite        | Specify angle, and animate gradient       |
 | hover-opts    | red,1s ease-in-out infinite    | Set hover effect color, and animate hover |
 | card-opts     | ,100                           | Use max opacity                           |
 
 **Note**: _You can also skip inner values, notice the first comma in **gradient-opts**. The type is not provided, so linear gradient will be used by default._
+
+---
+
+**Multi-tag with multi-style**
+
+`t_111,116,78,87/105_pink,red,white/orange,white_/,70deg,4s alternate infinite__,30/`
+
+| Segment       | Value                         | Meaning                                                                          |
+| ------------- | ----------------------------- | -------------------------------------------------------------------------------- |
+| criterion     | t                             | Tag-based                                                                        |
+| value         | 111,116,78,87/105             | Use tags 111, 116, 78, 87 or 105                                                 |
+| style         | pink,red,white/orange,white   | Apply pink, red, white gradient for first set of tags; orange, white for tag 105 |
+| gradient-opts | /,70deg,4s alternate infinite | No animation for first set of tags; 70deg, 4s alternate infinite for tag 105     |
+| hover-opts    |                               | Use default hover options                                                        |
+| card-opts     | ,30/                          | Set opacity to 30 for first set of tags; default opacity for tag 105             |
+
+---
+
+**Rating with multi-style**
+
+`r_5/4/3_gold/hot/default___//,50`
+
+| Segment       | Value            | Meaning                                                                               |
+| ------------- | ---------------- | ------------------------------------------------------------------------------------- |
+| criterion     | r                | Rating-based                                                                          |
+| value         | 5/4/3            | Use ratings 5, 4, and 3                                                               |
+| style         | gold/hot/default | Apply gold style to ratings 5, hot style to ratings 4, and default style to ratings 3 |
+| gradient-opts |                  | Use default gradient options                                                          |
+| hover-opts    |                  | Use default hover options                                                             |
+| card-opts     | //,50            | Set opacity to 50 for ratings 3; default opacity to other ratings                     |
+
+---
+
+**Multi-rating (tenth) with multi-style**
+
+`r_96,90,88/70,60_#0fff00/#000cff`
+
+| Segment       | Value           | Meaning                                                                    |
+| ------------- | --------------- | -------------------------------------------------------------------------- |
+| criterion     | r               | Rating-based                                                               |
+| value         | 96,90,88/70,60  | Use ratings 96, 90, 88 or 70, 60                                           |
+| style         | #0fff00/#000cff | Apply #0fff00 color to ratings 96, 90, 88; #000cff color to ratings 70, 60 |
+| gradient-opts |                 | Use default gradient options                                               |
+| hover-opts    |                 | Use default hover options                                                  |
+| card-opts     |                 | Use default card options                                                   |
 
 ## Style Presets
 

--- a/plugins/hotCards/hotCards.js
+++ b/plugins/hotCards/hotCards.js
@@ -4,10 +4,11 @@
   const userSettings = await csLib.getConfiguration("hotCards", {});
   const SEPARATOR = "_";
   const INNER_SEPARATOR = ",";
+  const INNER_SEGMENT_SEPARATOR = "/";
   const DEFAULTS = {
     criterion: "",
-    value: "",
-    style: "default",
+    value: [""],
+    style: ["default"],
     gradient_opts: {
       type: "linear",
       angle: "0deg",
@@ -84,30 +85,53 @@
 
     return {
       criterion: segments[0] || DEFAULTS.criterion,
-      value: segments[1] || DEFAULTS.value,
-      style: segments[2] || DEFAULTS.style,
-      gradient_opts: parseSegment(segments[3], DEFAULTS.gradient_opts, [
+      value: parseValues(segments[1]) || DEFAULTS.value,
+      style: parseValues(segments[2]) || DEFAULTS.style,
+      gradient_opts: parseArraySegment(segments[3], DEFAULTS.gradient_opts, [
         "type",
         "angle",
         "animation",
       ]),
-      hover_opts: parseSegment(segments[4], DEFAULTS.hover_opts, [
+      hover_opts: parseArraySegment(segments[4], DEFAULTS.hover_opts, [
         "color",
         "animation",
       ]),
-      card_opts: parseSegment(segments[5], DEFAULTS.card_opts, [
+      card_opts: parseArraySegment(segments[5], DEFAULTS.card_opts, [
         "fill",
         "opacity",
       ]),
     };
   }
 
-  function parseSegment(segment, defaults, keys) {
-    const values = segment ? segment.split(INNER_SEPARATOR) : [];
-    return keys.reduce((acc, key, index) => {
-      acc[key] = values[index] || defaults[key];
-      return acc;
-    }, {});
+  function parseArraySegment(segment, defaults, keys) {
+    if (!segment) return [defaults];
+
+    const parsedValues = parseValues(segment);
+
+    // If parsedValues is a single array, convert it to an array of arrays
+    const segmentsArray = Array.isArray(parsedValues[0])
+      ? parsedValues
+      : [parsedValues];
+
+    return segmentsArray.map((valuesArray) =>
+      keys.reduce((acc, key, index) => {
+        acc[key] = valuesArray[index] || defaults[key];
+        return acc;
+      }, {})
+    );
+  }
+
+  function parseValues(values) {
+    if (typeof values !== "string") return values;
+
+    const parts = values.split(INNER_SEGMENT_SEPARATOR);
+
+    if (parts.length === 1)
+      return parts[0].split(INNER_SEPARATOR).map((item) => item.trim());
+
+    return parts.map((part) =>
+      part.split(INNER_SEPARATOR).map((item) => item.trim())
+    );
   }
 
   // Mapping of configuration keys to functions
@@ -272,52 +296,87 @@
    * @param {boolean} isHome - Flag indicating if the current page is the homepage.
    */
   function createAndInsertHotCards(stashData, cardClass, config, isHome) {
-    const isCriterionTag = config.criterion === CRITERIA.tag;
-    const isCriterionRating = config.criterion === CRITERIA.rating;
-    const isCriterionEmpty = config.criterion.length === 0;
-    const valueNotSet = config.value.length === 0;
+    const { criterion, value } = config;
+    const cards = document.querySelectorAll(`.${cardClass}`);
     const isCriterionTagOrEmpty =
-      isTagBased && (isCriterionTag || isCriterionEmpty);
+      isTagBased && (criterion === CRITERIA.tag || criterion.length === 0);
     const isCriterionRatingOrEmpty =
-      isRatingBased && (isCriterionRating || isCriterionEmpty);
+      isRatingBased &&
+      (criterion === CRITERIA.rating || criterion.length === 0);
 
-    /**
-     * To avoid DOM exceptions, it runs if `hotCards` is empty and we are not in the home page
-     * or if we are in the home page.
-     */
-    if (hotCards.length === 0 || isHome) {
-      const cards = document.querySelectorAll(`.${cardClass}`);
+    // Skip processing if hotCards are already present and we're not on the home page.
+    if (hotCards.length !== 0 && !isHome) return;
 
-      cards.forEach((card) => {
-        const link = card.querySelector(".thumbnail-section > a");
-        const id = new URL(link.href).pathname.split("/").pop();
-        const data = stashData[id];
+    cards.forEach((card) => {
+      const link = card.querySelector(".thumbnail-section > a");
+      const id = new URL(link.href).pathname.split("/").pop();
+      const data = stashData[id];
 
-        if (isCriterionTagOrEmpty) {
-          if (data?.tags?.length) {
-            // If the tag ID for this card type is not set, use the default tag ID.
-            const tagId = valueNotSet ? TAG_ID : config.value;
-            data.tags.forEach((tag) => {
-              if (tag.id === tagId)
-                createHotElementAndAttachToDOM(card, cardClass, isHome);
-            });
-          }
-        } else if (isCriterionRatingOrEmpty && data?.rating100) {
-          const rating = isStarsRatingSystem
-            ? data.rating100 / 20
-            : data.rating100;
-          // If the rating threshold for this card type is not set, use the default threshold.
-          const ratingThreshold = valueNotSet ? RATING_THRESHOLD : config.value;
-          if (rating >= ratingThreshold)
-            createHotElementAndAttachToDOM(card, cardClass, isHome);
-        }
-      });
-    }
+      if (!data) return;
+
+      const valueSegment = findMatchingValueSegment(
+        value,
+        data.tags,
+        data.rating100,
+        isCriterionTagOrEmpty,
+        isCriterionRatingOrEmpty
+      );
+
+      if (valueSegment) {
+        const classId = valueSegment.join("-");
+        createHotElementAndAttachToDOM(card, cardClass, classId, isHome);
+      }
+    });
   }
 
-  function createHotElementAndAttachToDOM(cardElement, cardClass, isHome) {
+  function findMatchingValueSegment(
+    value,
+    tags,
+    rating,
+    isCriterionTagOrEmpty,
+    isCriterionRatingOrEmpty
+  ) {
+    for (let segment of value) {
+      const valueNotSet = segment.length === 0;
+      segment = Array.isArray(segment) ? segment : [segment];
+
+      if (
+        (isCriterionTagOrEmpty &&
+          matchesTagCriterion(tags, segment, valueNotSet)) ||
+        (isCriterionRatingOrEmpty &&
+          matchesRatingCriterion(rating, segment, valueNotSet))
+      )
+        return segment || [""];
+    }
+    return null;
+  }
+
+  function matchesTagCriterion(tags, valueSegment, valueNotSet) {
+    if (!tags) return false;
+
+    const tagIds = valueNotSet ? [TAG_ID] : valueSegment;
+    return tagIds.every((tag) => tags.some((t) => t.id === tag));
+  }
+
+  function matchesRatingCriterion(rating, valueSegment, valueNotSet) {
+    if (!rating) return false;
+
+    const parsedRating = isStarsRatingSystem ? rating / 20 : rating;
+    const ratingThresholds = valueNotSet ? [RATING_THRESHOLD] : valueSegment;
+    return ratingThresholds.length > 1
+      ? ratingThresholds.includes(parsedRating.toString())
+      : parsedRating >= ratingThresholds[0];
+  }
+
+  function createHotElementAndAttachToDOM(
+    cardElement,
+    className,
+    classId,
+    isHome
+  ) {
+    const hotCardClassName = `hot-${className}-${classId}`;
     const hotElement = createElementFromHTML(
-      `<div class="hot-card hot-${cardClass}">`
+      `<div class="hot-card ${hotCardClassName}">`
     );
     if (isHome) hotElement.style.height = "100%";
 
@@ -338,34 +397,41 @@
    * Sets the style of the hot card based on the user's configuration.
    */
   function setHotCardStyling(card) {
-    const { style, gradient_opts, hover_opts, card_opts } = card.config;
-    const colors = style.split(INNER_SEPARATOR).map((color) => color.trim());
+    const { value, style, gradient_opts, hover_opts, card_opts } = card.config;
 
-    const pseudoElementStyle =
-      colors.length === 1
+    const pseudoElementStyles = value.map((valueSegment, index) => {
+      valueSegment = Array.isArray(valueSegment)
+        ? valueSegment
+        : [valueSegment];
+      const classId = valueSegment.join("-");
+      return !Array.isArray(style[index]) || style[index].length === 1
         ? applySingleColorStyle(
-            card,
-            colors[0],
-            gradient_opts,
-            hover_opts,
-            card_opts
+            card.class,
+            classId,
+            style[index] || style[0],
+            gradient_opts[index] || gradient_opts[0],
+            hover_opts[index] || hover_opts[0],
+            card_opts[index] || card_opts[0]
           )
         : applyCustomGradientStyle(
-            card,
-            colors,
-            gradient_opts,
-            hover_opts,
-            card_opts
+            card.class,
+            classId,
+            style[index] || style[0],
+            gradient_opts[index] || gradient_opts[0],
+            hover_opts[index] || hover_opts[0],
+            card_opts[index] || card_opts[0]
           );
+    });
 
-    styleElement.innerHTML += pseudoElementStyle;
+    styleElement.innerHTML += pseudoElementStyles.join("");
   }
 
   /**
    * Apply a single color style, which can be a style preset or a fixed color.
    */
   function applySingleColorStyle(
-    card,
+    className,
+    classId,
     color,
     gradient_opts,
     hover_opts,
@@ -373,20 +439,22 @@
   ) {
     return STYLES[color]
       ? applyPresetStyle(
-          card,
+          className,
+          classId,
           STYLES[color],
           gradient_opts,
           hover_opts,
           card_opts
         )
-      : applyFixedColorStyle(card, color, hover_opts, card_opts);
+      : applyFixedColorStyle(className, classId, color, hover_opts, card_opts);
   }
 
   /**
    * Apply a style preset.
    */
   function applyPresetStyle(
-    card,
+    className,
+    classId,
     preset,
     gradient_opts,
     hover_opts,
@@ -411,7 +479,8 @@
     };
 
     return applyCustomGradientStyle(
-      card,
+      className,
+      classId,
       gradient.colors,
       updatedGradientOpts,
       updatedHoverOpts,
@@ -422,16 +491,28 @@
   /**
    * Apply a fixed color style.
    */
-  function applyFixedColorStyle(card, color, hover_opts, card_opts) {
-    setHoverStyleProperties(card, hover_opts.color, hover_opts.animation);
-    return getHotCardPseudoElementString(card, card_opts, color);
+  function applyFixedColorStyle(
+    className,
+    classId,
+    color,
+    hover_opts,
+    card_opts
+  ) {
+    setHoverStyleProperties(
+      className,
+      classId,
+      hover_opts.color,
+      hover_opts.animation
+    );
+    return getHotCardPseudoElementString(className, classId, card_opts, color);
   }
 
   /**
    * If there are more than one color, it's a custom gradient.
    */
   function applyCustomGradientStyle(
-    card,
+    className,
+    classId,
     colors,
     gradient_opts,
     hover_opts,
@@ -439,14 +520,25 @@
   ) {
     const { type, angle, animation } = gradient_opts;
     const gradient = getGradient(type, angle, colors);
-    setHoverStyleProperties(card, hover_opts.color, hover_opts.animation);
-    return getHotCardPseudoElementString(card, card_opts, gradient, animation);
+    setHoverStyleProperties(
+      className,
+      classId,
+      hover_opts.color,
+      hover_opts.animation
+    );
+    return getHotCardPseudoElementString(
+      className,
+      classId,
+      card_opts,
+      gradient,
+      animation
+    );
   }
 
-  function setHoverStyleProperties(card, color, animation) {
+  function setHoverStyleProperties(className, classId, color, animation) {
     const animationStr = animation ? `pulse ${animation}` : "";
     document
-      .querySelectorAll(`.hot-${card.class} > .hot-border`)
+      .querySelectorAll(`.hot-${className}-${classId} > .hot-border`)
       .forEach((hotBorderCard) => {
         hotBorderCard.style.setProperty("--hover-color", color);
         hotBorderCard.style.animation = animationStr;
@@ -459,7 +551,8 @@
   }
 
   function getHotCardPseudoElementString(
-    card,
+    className,
+    classId,
     card_opts,
     background,
     gradientAnimation = "",
@@ -472,7 +565,7 @@
       : "";
     const fillStr = fill ? `background-color: rgba(0, 0, 0, ${opacity});` : "";
     const filterStr = filter ? `filter: ${filter};` : "";
-    const hotCardClass = `.hot-${card.class}`;
+    const hotCardClass = `.hot-${className}-${classId}`;
 
     return `${hotCardClass}::before,
       ${hotCardClass}::after {

--- a/plugins/hotCards/hotCards.yml
+++ b/plugins/hotCards/hotCards.yml
@@ -1,6 +1,6 @@
 name: Hot Cards
-description: Adds custom styling to card elements that match a tag ID or a rating threshold.
-version: 1.1.2
+description: Adds custom styling to card elements that match a Tag ID or a Rating Threshold.
+version: 1.1.4
 url: https://github.com/stashapp/CommunityScripts/tree/main/plugins/hotCards
 # requires: CommunityScriptsUILibrary
 ui:


### PR DESCRIPTION
Multiple styles can now be applied to the same page depending on the rating values or tag values configured for each type of card.

This update won't break the current configured settings of any user, but it will allow for more flexibility.