### PR TITLE
[RenameFile] Fixed bug associated with rename

### DIFF
--- a/plugins/RenameFile/README.md
+++ b/plugins/RenameFile/README.md
@@ -37,10 +37,12 @@ To avoid this error, refresh the URL before changing the Title field.
 ### Installation
 - Follow **Requirements** instructions.
 - In the stash plugin directory (C:\Users\MyUserName\.stash\plugins), create a folder named **RenameFile**.
-- Copy all the plugin files to this folder.(**C:\Users\MyUserName\.stash\plugins\RenameFile**).
+- Copy all the plugin files to this folder.(**C:\Users\MyUserName\\.stash\plugins\RenameFile**).
 - Restart Stash.
 
 That's it!!!
 
 ### Options
-To change options, see **renamefile_settings.py** file. After making changes, go to http://localhost:9999/settings?tab=plugins, and click [Reload Plugins].
+- Main options are accessible in the GUI via Settings->Plugins->Plugins->[RenameFile].
+- Advanced options are avialable in the **renamefile_settings.py** file. After making changes, go to http://localhost:9999/settings?tab=plugins, and click [Reload Plugins].
+

--- a/plugins/RenameFile/renamefile.yml
+++ b/plugins/RenameFile/renamefile.yml
@@ -1,6 +1,6 @@
 name: RenameFile
 description: Renames video (scene) file names when the user edits the [Title] field located in the scene [Edit] tab.
-version: 0.2.5
+version: 0.2.6
 url: https://github.com/David-Maisonave/Axter-Stash/tree/main/plugins/RenameFile
 settings:
   dryRun:


### PR DESCRIPTION
There's was an (if not) condition which should have been an (if) condition. This caused issues when renaming a file without populating the title field and with an associated performer.

Sorry for the extra logging changes, but I had to throw in a lot of logging to find this bug, and I didn't want to remove it in case it's needed again.  The extra logging doesn't log unless user has the Debug-Trace option enabled.