### PR TITLE
Add companion plugin for StashAppAndroidTV

### DIFF
--- a/plugins/stashAppAndroidTvCompanion/stashAppAndroidTvCompanion.py
+++ b/plugins/stashAppAndroidTvCompanion/stashAppAndroidTvCompanion.py
@@ -1,0 +1,31 @@
+import sys
+import json
+import stashapi.log as log
+
+
+def do_logcat(args):
+    if "logcat" not in args:
+        log.error("logcat not found in args")
+        return
+    logs = args["logcat"]
+    log.info(logs)
+
+def do_crash_report(args):
+    if "crash_report" not in args:
+        log.error("report not found in args")
+        return
+    report = args["crash_report"]
+    log.error(report)
+
+json_input = json.loads(sys.stdin.read())
+
+args = json_input["args"]
+if "mode" in args:
+    mode = args["mode"]
+    if mode == "logcat":
+        do_logcat(args)
+    elif mode == "crash_report":
+        do_crash_report(args)
+    else:
+      log.warning("Unknown mode: " + mode)
+

--- a/plugins/stashAppAndroidTvCompanion/stashAppAndroidTvCompanion.yml
+++ b/plugins/stashAppAndroidTvCompanion/stashAppAndroidTvCompanion.yml
@@ -1,0 +1,18 @@
+name: StashAppAndroidTV Companion
+description: A companion plugin for StashAppAndroidTV
+version: 0.0.1
+url: https://github.com/damontecres/StashAppAndroidTV-Companion
+
+exec:
+  - python
+  - "{pluginDir}/stashAppAndroidTvCompanion.py"
+interface: raw
+tasks:
+  - name: logcat
+    description: Send android app's logcat logs
+    defaultArgs:
+      mode: logcat
+  - name: crash_report
+    description: Send android app's crash report
+    defaultArgs:
+      mode: crash_report


### PR DESCRIPTION
Adds a small companion plugin for my [Android TV Stash client](https://github.com/damontecres/StashAppAndroidTV).

This adds the ability for the Android TV app to send crash reports or other log information to the Stash server. The app will call the plugin tasks with a string arg that should be logged.

This is my first plugin, so happy to hear feedback!

Ref: https://github.com/damontecres/StashAppAndroidTV/pull/339