### PR TITLE
Add markerDeleteButton plugin.

### DIFF
--- a/plugins/markerDeleteButton/markerDeleteButton.css
+++ b/plugins/markerDeleteButton/markerDeleteButton.css
@@ -1,0 +1,11 @@
+.wall-item-container:hover .marker-delete-button {
+  display: block;
+}
+
+.marker-delete-button {
+  display: none;
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  opacity: 0.25;
+}

--- a/plugins/markerDeleteButton/markerDeleteButton.css
+++ b/plugins/markerDeleteButton/markerDeleteButton.css
@@ -4,8 +4,13 @@
 
 .marker-delete-button {
   display: none;
+  opacity: 0.25;
   position: absolute;
   top: 5px;
   right: 5px;
-  opacity: 0.25;
+  z-index: 999;
+}
+
+.marker-delete-button:hover {
+  opacity: 0.75;
 }

--- a/plugins/markerDeleteButton/markerDeleteButton.js
+++ b/plugins/markerDeleteButton/markerDeleteButton.js
@@ -6,15 +6,18 @@
     document
       .querySelectorAll("div.wall-item-container")
       .forEach(function (node) {
+        // Insert delete button.
         var deleteButton = document.createElement("div");
         deleteButton.innerHTML = markerDeleteButton;
         node.prepend(deleteButton);
 
+        // Parse marker ID.
         var markerImg = node
           .querySelector(".wall-item-media")
           .getAttribute("src");
         var markerID = markerImg.split("/")[6];
 
+        // Register click handler.
         deleteButton.addEventListener("click", function (e) {
           deleteMarker(markerID);
         });
@@ -29,7 +32,7 @@
     });
   }
 
-  // Wait for video player to load on scene page.
+  // Wait for markers page to load.
   csLib.PathElementListener(
     "/scenes/markers",
     "div.wall",

--- a/plugins/markerDeleteButton/markerDeleteButton.js
+++ b/plugins/markerDeleteButton/markerDeleteButton.js
@@ -1,0 +1,38 @@
+(async () => {
+  const markerDeleteButton =
+    '<button class="marker-delete-button btn btn-danger">Delete</button>';
+
+  async function setupMarkerDeleteButton() {
+    document
+      .querySelectorAll("div.wall-item-container")
+      .forEach(function (node) {
+        var deleteButton = document.createElement("div");
+        deleteButton.innerHTML = markerDeleteButton;
+        node.prepend(deleteButton);
+
+        var markerImg = node
+          .querySelector(".wall-item-media")
+          .getAttribute("src");
+        var markerID = markerImg.split("/")[6];
+
+        deleteButton.addEventListener("click", function (e) {
+          deleteMarker(markerID);
+        });
+      });
+  }
+
+  async function deleteMarker(markerID) {
+    const variables = { id: markerID };
+    const query = `mutation SceneMarkerDestroy($id: ID!) {sceneMarkerDestroy(id: $id)}`;
+    await csLib.callGQL({ query, variables }).then(() => {
+      window.location.reload();
+    });
+  }
+
+  // Wait for video player to load on scene page.
+  csLib.PathElementListener(
+    "/scenes/markers",
+    "div.wall",
+    setupMarkerDeleteButton
+  ); // PathElementListener is from cs-ui-lib.js
+})();

--- a/plugins/markerDeleteButton/markerDeleteButton.yml
+++ b/plugins/markerDeleteButton/markerDeleteButton.yml
@@ -1,0 +1,11 @@
+name: Marker Delete Button
+# requires: CommunityScriptsUILibrary
+description: Adds a delete button to entries on the Markers page.
+version: 0.1
+ui:
+  requires:
+    - CommunityScriptsUILibrary
+  javascript:
+    - markerDeleteButton.js
+  css:
+    - markerDeleteButton.css


### PR DESCRIPTION
This adds the markerDeleteButton plugin. This is a very small plugin that just adds a `Delete` button to entries on the Markers page. Clicking this will delete the associated Marker through GQL and reload the page. The button is hidden until the user hovers over the Marker entry on the page and then is low opacity until hovering over the button.

I considered adding a confirmation upon clicking the button, but the odds of a misclick seem relatively low to me. If people use this plugin and end up wanting that though, I could add it as a configurable option.

I can't really say how many people will want this plugin. For me, I use Markers as more of a highlights/favorites feature, and when I come across a marker with a boring preview that I want to get rid of, the current process of deleting it is very cumbersome. This plugin streamlines that process to a single click.

![image](https://github.com/user-attachments/assets/2e739567-2cee-48c2-bc1c-224808db82f1)
