### PR TITLE
[VideoScrollWheel] Fix infinite loop when scrolling near start/end

### DIFF
--- a/plugins/VideoScrollWheel/VideoScrollWheel.js
+++ b/plugins/VideoScrollWheel/VideoScrollWheel.js
@@ -96,11 +96,21 @@
         while (vjsPlayer.currentTime() < newTime) {
           vjsPlayer.currentTime(newTime + extraDelta);
           ++extraDelta;
+
+          if (vjsPlayer.currentTime() + extraDelta >= vjsPlayer.duration()) {
+            vjsPlayer.currentTime(vjsPlayer.duration());
+            break;
+          }
         }
       } else {
         while (vjsPlayer.currentTime() > newTime) {
           vjsPlayer.currentTime(newTime - extraDelta);
           ++extraDelta;
+
+          if (vjsPlayer.currentTime() - extraDelta <= 0) {
+            vjsPlayer.currentTime(0);
+            break;
+          }
         }
       }
     }

--- a/plugins/VideoScrollWheel/VideoScrollWheel.yml
+++ b/plugins/VideoScrollWheel/VideoScrollWheel.yml
@@ -1,7 +1,7 @@
 name: VideoScrollWheel
 # requires: CommunityScriptsUILibrary
 description: Adds functionality to change volume/time in scene video player by hovering over left/right side of player and scrolling with mouse scrollwheel. Scroll while hovering on left side to adjust volume, scroll on right side to skip forward/back.
-version: 0.3
+version: 0.4
 settings:
   allowVolumeChange:
     displayName: Volume change via mouse wheel


### PR DESCRIPTION
When scrolling to time skip near the start or end of the video, the plugin would enter an infinite loop and crash the tab/browser. If the time delta would cause this to happen, the plugin will now set the video to the very start/end and break the loop.