### PR TITLE
A few more features, funscripts matching, excluding markers with matching strings and changes to marker titles and tags

### DIFF
--- a/plugins/timestampTrade/timestampTrade.py
+++ b/plugins/timestampTrade/timestampTrade.py
@@ -18,6 +18,7 @@ request_s = requests.Session()
 scrapers = {}
 tags_cache = {}
 
+
 def processScene(s):
     if "https://timestamp.trade/scene/" in [u[:30] for u in s["urls"]]:
         processSceneTimestamTrade(s)
@@ -41,9 +42,9 @@ def processSceneTimestamTrade(s):
                     if len(data) == 0:
                         log.debug("no scene metadata")
                         return
-#                    log.debug(data)
-#                    log.debug(s["scene_markers"])
-#                    log.debug(len(s["scene_markers"]) > 0)
+                    #                    log.debug(data)
+                    #                    log.debug(s["scene_markers"])
+                    #                    log.debug(len(s["scene_markers"]) > 0)
                     if settings["createMarkers"]:
                         log.debug("creating markers")
                         markers = []
@@ -67,13 +68,16 @@ def processSceneTimestamTrade(s):
                             if settings["addTsTradeTitle"]:
                                 marker["title"] = f"[TsTrade] {m["name"]}"
 
-                            #check for markers with a zero length title, skip adding
+                            # check for markers with a zero length title, skip adding
                             if len(marker["primary_tag"]) == 0:
                                 True
                             elif excluded_marker_tag(marker):
                                 True
                             # check for duplicate markers
-                            elif marker["title"] == previous["title"] and marker["seconds"] == previous["seconds"]:
+                            elif (
+                                marker["title"] == previous["title"]
+                                and marker["seconds"] == previous["seconds"]
+                            ):
                                 True
                             else:
                                 markers.append(marker)
@@ -84,9 +88,10 @@ def processSceneTimestamTrade(s):
                             if settings["overwriteMarkers"]:
                                 stash.destroy_scene_markers(s["id"])
                                 mp.import_scene_markers(stash, markers, s["id"], 15)
-                            elif len(s["scene_markers"]) == 0 or settings["mergeMarkers"]:
+                            elif (
+                                len(s["scene_markers"]) == 0 or settings["mergeMarkers"]
+                            ):
                                 mp.import_scene_markers(stash, markers, s["id"], 15)
-
 
                     new_scene = {
                         "id": s["id"],
@@ -94,8 +99,8 @@ def processSceneTimestamTrade(s):
                     needs_update = False
                     if settings["createGalleryFromScene"]:
                         for g in data["galleries"]:
-                            if len(g) ==0:
-                                break;
+                            if len(g) == 0:
+                                break
                             for f in g["files"]:
                                 log.debug(f)
                                 res = stash.find_galleries(
@@ -129,7 +134,7 @@ def processSceneTimestamTrade(s):
                                         "details": gal["details"],
                                     }
                                     if "studio" in gal:
- #                                       log.debug(s["studio"])
+                                        #                                       log.debug(s["studio"])
                                         if gal["studio"]:
                                             gallery["studio_id"] = gal["studio"]["id"]
                                         elif s["studio"]["id"]:
@@ -170,9 +175,14 @@ def processSceneTimestamTrade(s):
                             movies_to_add = []
                             for m in data["movies"]:
                                 log.debug("movie: %s" % (m,))
-#                                log.debug("scene: %s" % (s,))
+                                #                                log.debug("scene: %s" % (s,))
                                 movies = []
-                                m["urls"].append({"url":"https://timestamp.trade/movie/%s" % (m["id"],)})
+                                m["urls"].append(
+                                    {
+                                        "url": "https://timestamp.trade/movie/%s"
+                                        % (m["id"],)
+                                    }
+                                )
                                 scene_index = None
                                 for sc in m["scenes"]:
                                     if sc["scene_id"] == data["scene_id"]:
@@ -186,7 +196,7 @@ def processSceneTimestamTrade(s):
                                             }
                                         }
                                     )
-#                                    log.debug("sm: %s" % (sm,))
+                                    #                                    log.debug("sm: %s" % (sm,))
                                     movies.extend(sm)
                                 if len(movies) == 0:
                                     # we need to determine what scrapers we have and what url patterns they accept, query what url patterns are supported, should only need to check once
@@ -234,7 +244,7 @@ def processSceneTimestamTrade(s):
                                                         "synopsis": movie_scrape[
                                                             "synopsis"
                                                         ],
-#                                                        "url": movie_scrape["url"],
+                                                        #                                                        "url": movie_scrape["url"],
                                                         "front_image": movie_scrape[
                                                             "front_image"
                                                         ],
@@ -255,7 +265,9 @@ def processSceneTimestamTrade(s):
                                                             ]
                                                         )
                                                     if settings["schema"] >= 63:
-                                                        new_movie["urls"]=[x["url"] for x in m["urls"]]
+                                                        new_movie["urls"] = [
+                                                            x["url"] for x in m["urls"]
+                                                        ]
                                                     log.debug(
                                                         "new movie: %s" % (new_movie,)
                                                     )
@@ -276,7 +288,7 @@ def processSceneTimestamTrade(s):
                                         log.debug("new movie: %s" % (new_movie,))
                                         nm = stash.create_movie(new_movie)
                                         if nm:
-                                            new_movie["urls"]=m["urls"]
+                                            new_movie["urls"] = m["urls"]
                                 movies_to_add.extend(
                                     [
                                         {
@@ -287,31 +299,53 @@ def processSceneTimestamTrade(s):
                                     ]
                                 )
                             if len(movies_to_add) > 0:
-                                if settings["schema"] >=64:
-                                    new_scene["movies"] = [{'movie_id':x["group"]["id"],'scene_index':x["scene_index"]} for x in s["groups"]]
+                                if settings["schema"] >= 64:
+                                    new_scene["movies"] = [
+                                        {
+                                            "movie_id": x["group"]["id"],
+                                            "scene_index": x["scene_index"],
+                                        }
+                                        for x in s["groups"]
+                                    ]
                                 else:
-                                    new_scene["movies"] = [{'movie_id':x["movie"]["id"],'scene_index':x["scene_index"]} for x in s["movies"]]
+                                    new_scene["movies"] = [
+                                        {
+                                            "movie_id": x["movie"]["id"],
+                                            "scene_index": x["scene_index"],
+                                        }
+                                        for x in s["movies"]
+                                    ]
                                 for m in movies_to_add:
-                                    if m["movie_id"] not in [x["movie_id"] for x in new_scene["movies"]]:
+                                    if m["movie_id"] not in [
+                                        x["movie_id"] for x in new_scene["movies"]
+                                    ]:
                                         new_scene["movies"].append(m)
                                         needs_update = True
-#                    log.debug(s)
-                    if getTag("[Timestamp: Auto Gallery]") in [x["id"] for x in s["tags"]]:
-                        autoGallery=True
+                    #                    log.debug(s)
+                    if getTag("[Timestamp: Auto Gallery]") in [
+                        x["id"] for x in s["tags"]
+                    ]:
+                        autoGallery = True
                         for g in s["galleries"]:
-                            gal=stash.find_gallery(g['id'])
-                            if getTag("[Timestamp: Auto Gallery]") in [x["id"] for x in gal["tags"]]:
-                                autoGallery=False
+                            gal = stash.find_gallery(g["id"])
+                            if getTag("[Timestamp: Auto Gallery]") in [
+                                x["id"] for x in gal["tags"]
+                            ]:
+                                autoGallery = False
                         if autoGallery:
-                            g1 = stash.find_galleries(f={"url": {"modifier": "EQUALS", "value": url }})
+                            g1 = stash.find_galleries(
+                                f={"url": {"modifier": "EQUALS", "value": url}}
+                            )
                             if len(g1) > 0:
                                 if "gallery_ids" not in new_scene:
-                                    new_scene["gallery_ids"] = [x["id"] for x in s["galleries"]]
+                                    new_scene["gallery_ids"] = [
+                                        x["id"] for x in s["galleries"]
+                                    ]
                                 for g2 in g1:
-                                    if g2['id'] not in new_scene["gallery_ids"]:
-                                        new_scene["gallery_ids"].append(g2['id'])
+                                    if g2["id"] not in new_scene["gallery_ids"]:
+                                        new_scene["gallery_ids"].append(g2["id"])
                                         needs_update = True
-                                        autoGallery=False
+                                        autoGallery = False
                         if autoGallery:
                             log.debug("creating auto gallery")
                             # check the gallery if we have already
@@ -326,13 +360,17 @@ def processSceneTimestamTrade(s):
                                 "performer_ids": [x["id"] for x in s["performers"]],
                             }
                             if s["studio"]:
-                                gallery_input["studio_id"]=s["studio"]["id"]
-                            gallery_input["tag_ids"].append(getTag("[Timestamp: Auto Gallery]"))
-                            gallery_input["tag_ids"].append(getTag("[Timestamp: Skip Submit]"))
+                                gallery_input["studio_id"] = s["studio"]["id"]
+                            gallery_input["tag_ids"].append(
+                                getTag("[Timestamp: Auto Gallery]")
+                            )
+                            gallery_input["tag_ids"].append(
+                                getTag("[Timestamp: Skip Submit]")
+                            )
                             gal = stash.create_gallery(gallery_input)
-                            new_scene["gallery_ids"]=[x["id"] for x in s["galleries"]]
+                            new_scene["gallery_ids"] = [x["id"] for x in s["galleries"]]
                             new_scene["gallery_ids"].append(gal)
-                            needs_update= True
+                            needs_update = True
                         else:
                             log.debug("auto gallery already exists")
                     log.debug(data.keys())
@@ -343,27 +381,41 @@ def processSceneTimestamTrade(s):
                                 log.debug(fs["md5"])
                                 conn = db_migrations()
                                 cur = conn.cursor()
-                                res = cur.execute("select id,filename,scene_id from script_index where md5=?", (fs["md5"],));
+                                res = cur.execute(
+                                    "select id,filename,scene_id from script_index where md5=?",
+                                    (fs["md5"],),
+                                )
                                 for row in res.fetchall():
                                     if len(s["files"]) > 0:
-                                        log.debug("found matching funscript, copying funscript")
-                                        scriptfile_source=Path(row[1])
-                                        video_file=Path(s["files"][0]["path"])
-                                        scriptfile_destination = video_file.parent / (video_file.stem + ".funscript")
-                                        log.info("copying funscript %s, to destination %s,"% (scriptfile_source,scriptfile_destination,))
-                                        shutil.copyfile(scriptfile_source,scriptfile_destination)
+                                        log.debug(
+                                            "found matching funscript, copying funscript"
+                                        )
+                                        scriptfile_source = Path(row[1])
+                                        video_file = Path(s["files"][0]["path"])
+                                        scriptfile_destination = video_file.parent / (
+                                            video_file.stem + ".funscript"
+                                        )
+                                        log.info(
+                                            "copying funscript %s, to destination %s,"
+                                            % (
+                                                scriptfile_source,
+                                                scriptfile_destination,
+                                            )
+                                        )
+                                        shutil.copyfile(
+                                            scriptfile_source, scriptfile_destination
+                                        )
 
                     if needs_update:
                         log.debug("updating scene: %s" % (new_scene,))
                         stash.update_scene(new_scene)
 
 
-
 def processSceneStashid(s):
     if len(s["stash_ids"]) == 0:
         log.debug("no scenes to process")
         return
-#    skip_sync_tag_id = stash.find_tag("[Timestamp: Skip Sync]", create=True).get("id")
+    #    skip_sync_tag_id = stash.find_tag("[Timestamp: Skip Sync]", create=True).get("id")
 
     for sid in s["stash_ids"]:
         try:
@@ -382,16 +434,24 @@ def processSceneStashid(s):
                 log.debug("bad result from api, skipping")
                 return
             if "scene_id" in md:
-                if settings["addTimestampTradeUrl"] and "https://timestamp.trade/scene/" not in [u[:30] for u in s["urls"]]:
+                if settings[
+                    "addTimestampTradeUrl"
+                ] and "https://timestamp.trade/scene/" not in [
+                    u[:30] for u in s["urls"]
+                ]:
                     new_scene = {
                         "id": s["id"],
                         "urls": s["urls"],
                     }
-                    s["urls"].append("https://timestamp.trade/scene/%s" % (md["scene_id"],))
+                    s["urls"].append(
+                        "https://timestamp.trade/scene/%s" % (md["scene_id"],)
+                    )
                     log.debug("new scene update: %s" % (new_scene,))
                     stash.update_scene(new_scene)
                 else:
-                    s["urls"].append("https://timestamp.trade/scene/%s" % (md["scene_id"],))
+                    s["urls"].append(
+                        "https://timestamp.trade/scene/%s" % (md["scene_id"],)
+                    )
 
         except json.decoder.JSONDecodeError:
             log.error("api returned invalid JSON for stash id: " + sid["stash_id"])
@@ -406,10 +466,10 @@ def processAll(query):
         get_count=True,
     )[0]
     log.info(str(count) + " scenes to process.")
-#    i = 0
+    #    i = 0
     # 98
     for r in range(1, int(count / per_page) + 2):
-        i=(r-1)*per_page
+        i = (r - 1) * per_page
         log.info(
             "fetching data: %s - %s %0.1f%%"
             % (
@@ -635,15 +695,24 @@ def submitScene(query):
             log.debug("submitting scene: " + str(s))
             if settings["submitFunscriptHash"]:
                 log.debug(s)
-                s["funscriptHashes"]=[]
-                conn=db_migrations()
-                cur=conn.cursor()
-                res=cur.execute("select id,filename,metadata,scene_id,md5 from script_index where scene_id=?",(s["id"],))
+                s["funscriptHashes"] = []
+                conn = db_migrations()
+                cur = conn.cursor()
+                res = cur.execute(
+                    "select id,filename,metadata,scene_id,md5 from script_index where scene_id=?",
+                    (s["id"],),
+                )
                 for row in res.fetchall():
-                    s["funscriptHashes"].append({"filename": str(Path(row[1]).name),"metadata":json.loads(row[2]), "md5": row[4]})
+                    s["funscriptHashes"].append(
+                        {
+                            "filename": str(Path(row[1]).name),
+                            "metadata": json.loads(row[2]),
+                            "md5": row[4],
+                        }
+                    )
             s.pop("id")
             log.debug(s)
-#            request_s.post("https://timestamp.trade/submit-stash", json=s)
+            #            request_s.post("https://timestamp.trade/submit-stash", json=s)
             i = i + 1
             log.progress((i / count))
             time.sleep(0.5)
@@ -725,7 +794,7 @@ def submitGallery():
         get_count=True,
         fragment=scene_fgmt,
     )[0]
-#    log.debug(count)
+    #    log.debug(count)
     i = 500
     for r in range(1, math.ceil(count / per_page) + 1):
         log.info(
@@ -939,15 +1008,14 @@ def processGallery(gallery):
                         log.debug("bad response from api")
                         time.sleep(10)
 
+
 def downloadGallery(gallery):
     dir = Path(settings["path"])
     dir.mkdir(parents=True, exist_ok=True)
-    scene={}
-    if len(gallery["scenes"])==1:
-        scene=stash.find_scene(gallery["scenes"][0]["id"])
-        log.debug('scene: %s' % (scene,))
-
-
+    scene = {}
+    if len(gallery["scenes"]) == 1:
+        scene = stash.find_scene(gallery["scenes"][0]["id"])
+        log.debug("scene: %s" % (scene,))
 
     for url in gallery["urls"]:
         log.debug(url)
@@ -961,50 +1029,63 @@ def downloadGallery(gallery):
                     log.debug("no scene metadata")
                     return
                 log.info("Processing auto Gallery")
-                counts={"gallery":1,"cover":1}
-                for i in data['images']:
+                counts = {"gallery": 1, "cover": 1}
+                for i in data["images"]:
 
                     log.debug(i)
                     # have we downloaded this image before? check for images with that url, if no results download it
-                    img= stash.find_images(f={"url": {"modifier": "EQUALS","value": i["url"]	}})
-                    if len(img) ==0:
-                        image_id=uuid.uuid4().hex
-                        image_file=Path(settings["path"]) / (image_id +'.jpg')
-                        metadata_file = Path(settings["path"]) / (image_id +".json")
+                    img = stash.find_images(
+                        f={"url": {"modifier": "EQUALS", "value": i["url"]}}
+                    )
+                    if len(img) == 0:
+                        image_id = uuid.uuid4().hex
+                        image_file = Path(settings["path"]) / (image_id + ".jpg")
+                        metadata_file = Path(settings["path"]) / (image_id + ".json")
                         image_data = {
                             "title": "%s - %s "
-                                     % (
-                                         i["type"],
-                                         counts[i["type"]],
-                                     ),
+                            % (
+                                i["type"],
+                                counts[i["type"]],
+                            ),
                             "details": "",
                             "urls": [i["url"]],
                             "performer_ids": [],
-                            "tag_ids": [getTag("[Timestamp: Auto Gallery]"),getTag("[Timestamp: Skip Submit]")],
-                            "gallery_ids": [
-                                gallery["id"]
+                            "tag_ids": [
+                                getTag("[Timestamp: Auto Gallery]"),
+                                getTag("[Timestamp: Skip Submit]"),
                             ],
+                            "gallery_ids": [gallery["id"]],
                         }
                         if gallery["studio"]:
-                                image_data["studio_id"]=gallery["studio"]["id"]
-                        if i["type"]=="cover":
+                            image_data["studio_id"] = gallery["studio"]["id"]
+                        if i["type"] == "cover":
                             image_data["tag_ids"].append(getTag("[Timestamp: Cover]"))
                         elif i["type"] == "gallery":
-                            image_data["tag_ids"].append(getTag("[Timestamp: Gallery Image]"))
+                            image_data["tag_ids"].append(
+                                getTag("[Timestamp: Gallery Image]")
+                            )
 
                         if scene:
-                            image_data["performer_ids"].extend([x["id"] for x in scene["performers"]])
+                            image_data["performer_ids"].extend(
+                                [x["id"] for x in scene["performers"]]
+                            )
                         else:
                             for p in data["performers"]:
-                                perf=stash.find_performers(q=p["name"])
+                                perf = stash.find_performers(q=p["name"])
                                 for p1 in perf:
                                     image_data["performer_ids"].append(p1["id"])
 
                         log.debug(image_data)
-                        log.info("Downloading image %s to file %s" % (i["url"],str(image_file),))
+                        log.info(
+                            "Downloading image %s to file %s"
+                            % (
+                                i["url"],
+                                str(image_file),
+                            )
+                        )
                         try:
                             r = requests.get(i["url"])
-                            if r.status_code==200:
+                            if r.status_code == 200:
                                 with open(metadata_file, "w") as f:
                                     json.dump(image_data, f)
                                 with open(image_file, "wb") as f:
@@ -1013,16 +1094,16 @@ def downloadGallery(gallery):
                         except requests.RequestException as e:
                             log.error(e)
                     else:
-                        log.debug('img: %s' % (img[0],))
+                        log.debug("img: %s" % (img[0],))
 
-                        new_image= {"id": img[0]["id"]}
-                        needs_update=False
-                        if len(img[0]["performers"]) ==0:
-                            new_image["performer_ids"]= []
-                            needs_update= True
+                        new_image = {"id": img[0]["id"]}
+                        needs_update = False
+                        if len(img[0]["performers"]) == 0:
+                            new_image["performer_ids"] = []
+                            needs_update = True
                             for p in data["performers"]:
                                 log.debug(p["name"])
-                                perf= stash.find_performers(q=p["name"])
+                                perf = stash.find_performers(q=p["name"])
                                 for p1 in perf:
                                     new_image["performer_ids"].append(p1["id"])
 
@@ -1032,16 +1113,17 @@ def downloadGallery(gallery):
 
                         True
 
-                    counts[i["type"]]=counts[i["type"]]+1
+                    counts[i["type"]] = counts[i["type"]] + 1
+
 
 def reDownloadGallery():
-    query={
+    query = {
         "tags": {
-                "depth": 0,
-                "excludes": [],
-                "modifier": "INCLUDES_ALL",
-                "value": [getTag("[Timestamp: Auto Gallery]")],
-            }
+            "depth": 0,
+            "excludes": [],
+            "modifier": "INCLUDES_ALL",
+            "value": [getTag("[Timestamp: Auto Gallery]")],
+        }
     }
     log.info("Getting gallery count")
     count = stash.find_galleries(
@@ -1051,7 +1133,7 @@ def reDownloadGallery():
     )[0]
     log.info(str(count) + " galleries to process.")
     for r in range(1, int(count / per_page) + 2):
-        i= (r-1)*per_page
+        i = (r - 1) * per_page
         log.info(
             "fetching data: %s - %s %0.1f%%"
             % (
@@ -1069,8 +1151,6 @@ def reDownloadGallery():
             i = i + 1
             log.progress((i / count))
             time.sleep(2)
-
-
 
 
 def getImages(gallery_id):
@@ -1092,10 +1172,11 @@ def getImages(gallery_id):
         print(img)
     print(images)
 
+
 def getTag(name):
     if name not in tags_cache:
-        tag=stash.find_tag(name, create=True)
-        tags_cache[name]=tag.get("id")
+        tag = stash.find_tag(name, create=True)
+        tags_cache[name] = tag.get("id")
     return tags_cache[name]
 
 
@@ -1119,56 +1200,89 @@ def processImages(img):
         #        log.debug(image_data)
         stash.update_image(image_data)
 
+
 def db_migrations():
     con = sqlite3.connect(settings["funscript_dbpath"])
     cur = con.cursor()
-    res=cur.execute("SELECT count(name) FROM sqlite_master WHERE type='table' and name='schema_migrations'")
-    if res.fetchone()[0]==0:
+    res = cur.execute(
+        "SELECT count(name) FROM sqlite_master WHERE type='table' and name='schema_migrations'"
+    )
+    if res.fetchone()[0] == 0:
         log.debug("creating table")
-        cur.execute("CREATE TABLE schema_migrations (version uint64,start timestamp,dirty bool);")
-        cur.execute("insert into schema_migrations (version,start,dirty ) values (0,datetime('now'),false);")
+        cur.execute(
+            "CREATE TABLE schema_migrations (version uint64,start timestamp,dirty bool);"
+        )
+        cur.execute(
+            "insert into schema_migrations (version,start,dirty ) values (0,datetime('now'),false);"
+        )
         con.commit()
-    res=cur.execute("select max(version) from schema_migrations;")
-    funscript_schema=res.fetchone()[0]
-    if funscript_schema ==0:
-        cur.execute("insert into schema_migrations (version,start,dirty ) values (1,datetime('now'),true);")
-        cur.execute("CREATE TABLE script_index (id INTEGER PRIMARY KEY, filename text,metadata text,scene_id text,md5 text);")
-        cur.execute('update schema_migrations set dirty=False where version=1')
+    res = cur.execute("select max(version) from schema_migrations;")
+    funscript_schema = res.fetchone()[0]
+    if funscript_schema == 0:
+        cur.execute(
+            "insert into schema_migrations (version,start,dirty ) values (1,datetime('now'),true);"
+        )
+        cur.execute(
+            "CREATE TABLE script_index (id INTEGER PRIMARY KEY, filename text,metadata text,scene_id text,md5 text);"
+        )
+        cur.execute("update schema_migrations set dirty=False where version=1")
     return con
 
 
 def funscript_index(path):
-    conn= db_migrations()
+    conn = db_migrations()
     cur = conn.cursor()
     for file in path.glob("**/*.funscript"):
-        log.info('indexing script file %s' % (file,))
-        with open(file, 'rb') as f:
+        log.info("indexing script file %s" % (file,))
+        with open(file, "rb") as f:
             data = f.read()
             hash = hashlib.md5(data).hexdigest()
             log.debug(hash)
             d = json.loads(data)
-            metadata={}
+            metadata = {}
             if "metadata" in d:
-                metadata=d["metadata"]
-            res=cur.execute('select count(*) from script_index where filename=? ', (str(file.resolve()),))
-            if res.fetchone()[0]==0:
-                cur.execute('insert into script_index (filename,metadata,md5)values (?,?,?)',(str(file.resolve()),json.dumps(metadata),hash))
+                metadata = d["metadata"]
+            res = cur.execute(
+                "select count(*) from script_index where filename=? ",
+                (str(file.resolve()),),
+            )
+            if res.fetchone()[0] == 0:
+                cur.execute(
+                    "insert into script_index (filename,metadata,md5)values (?,?,?)",
+                    (str(file.resolve()), json.dumps(metadata), hash),
+                )
                 conn.commit()
-    res = cur.execute('select count(*) from script_index ')
-    funscript_count=res.fetchone()[0]
-    log.info('finished indexing funscripts, %s scripts indexed, matching to scenes' % (funscript_count,))
-    res=cur.execute("select id,filename,scene_id from script_index where scene_id is null;");
+    res = cur.execute("select count(*) from script_index ")
+    funscript_count = res.fetchone()[0]
+    log.info(
+        "finished indexing funscripts, %s scripts indexed, matching to scenes"
+        % (funscript_count,)
+    )
+    res = cur.execute(
+        "select id,filename,scene_id from script_index where scene_id is null;"
+    )
     for row in res.fetchall():
-        id=row[0]
-        filename=row[1]
-        scenes=stash.find_scenes(f={"path": {"modifier": "INCLUDES", "value": Path(filename).stem}},fragment="id\nfiles{basename}")
-        i=0
+        id = row[0]
+        filename = row[1]
+        scenes = stash.find_scenes(
+            f={"path": {"modifier": "INCLUDES", "value": Path(filename).stem}},
+            fragment="id\nfiles{basename}",
+        )
+        i = 0
         for s in scenes:
 
             for f in s["files"]:
-                if Path(filename).stem == Path(f['basename']).stem:
-                    log.info("matching scene %s to script %s" % (s["id"], filename,))
-                    cur.execute("update script_index set scene_id=? where id=?", (s["id"], id))
+                if Path(filename).stem == Path(f["basename"]).stem:
+                    log.info(
+                        "matching scene %s to script %s"
+                        % (
+                            s["id"],
+                            filename,
+                        )
+                    )
+                    cur.execute(
+                        "update script_index set scene_id=? where id=?", (s["id"], id)
+                    )
             conn.commit()
 
 
@@ -1187,7 +1301,7 @@ def excluded_marker_tag(marker):
         for word in settings.get("excludedMarkerWords", "").split(",")
         if len(word.strip()) >= 4 and clean_input_pattern.match(word.strip())
     }
-    primary_tag_words = re.sub(r'[^\w\s]', '', marker["primary_tag"].lower()).split()
+    primary_tag_words = re.sub(r"[^\w\s]", "", marker["primary_tag"].lower()).split()
     if any(
         tag_word.startswith(word) and len(tag_word) - len(word) <= 3
         for word in excluded_words
@@ -1196,9 +1310,6 @@ def excluded_marker_tag(marker):
         log.info(f'EXCLUDE: {marker["primary_tag"]} @ {marker["seconds"]}')
         return True
     return False
-
-
-
 
 
 json_input = json.loads(sys.stdin.read())
@@ -1217,19 +1328,21 @@ settings = {
     "overwriteMarkers": False,
     "mergeMarkers": False,
     "createGalleries": True,
-    "submitFunscriptHash":True,
-    "excludedMarkerWords":"",
-    "matchFunscripts":True,
-    "addTsTradeTitle":False,
+    "submitFunscriptHash": True,
+    "excludedMarkerWords": "",
+    "matchFunscripts": True,
+    "addTsTradeTitle": False,
 }
 if "timestampTrade" in config["plugins"]:
     settings.update(config["plugins"]["timestampTrade"])
 
 
 # check the schema version for features in the dev release
-res=stash.callGQL("{systemStatus {databaseSchema databasePath}}")
-settings["schema"]=res["systemStatus"]["databaseSchema"]
-settings["funscript_dbpath"]=Path (res["systemStatus"]["databasePath"]).parent / "funscript_index.sqlite"
+res = stash.callGQL("{systemStatus {databaseSchema databasePath}}")
+settings["schema"] = res["systemStatus"]["databaseSchema"]
+settings["funscript_dbpath"] = (
+    Path(res["systemStatus"]["databasePath"]).parent / "funscript_index.sqlite"
+)
 log.debug("settings: %s " % (settings,))
 
 

--- a/plugins/timestampTrade/timestampTrade.py
+++ b/plugins/timestampTrade/timestampTrade.py
@@ -712,7 +712,7 @@ def submitScene(query):
                     )
             s.pop("id")
             log.debug(s)
-            #            request_s.post("https://timestamp.trade/submit-stash", json=s)
+            request_s.post("https://timestamp.trade/submit-stash", json=s)
             i = i + 1
             log.progress((i / count))
             time.sleep(0.5)

--- a/plugins/timestampTrade/timestampTrade.yml
+++ b/plugins/timestampTrade/timestampTrade.yml
@@ -109,4 +109,3 @@ tasks:
     description: scan for funscript files to be matched and submitted
     defaultArgs:
       mode: indexFunscripts
-

--- a/plugins/timestampTrade/timestampTrade.yml
+++ b/plugins/timestampTrade/timestampTrade.yml
@@ -1,6 +1,6 @@
 name: Timestamp Trade
 description: Sync Markers with timestamp.trade, a new database for sharing markers.
-version: 0.7
+version: 0.8
 url: https://github.com/stashapp/CommunityScripts/
 exec:
   - python
@@ -35,6 +35,26 @@ settings:
     displayName: Download parent folder
     description: Download location for files, note this should be in a different folder to stash and in a folder covered by stash. You may need to create a new library path to cover this directory.
     type: STRING
+  addTsTradeTag:
+    displayName: Add the [Timestamp] tag to created markers.
+    type: BOOLEAN
+  addTsTradeTitle:
+    displayName: Add "TsTrade" to the start of generated marker titles.
+    type: BOOLEAN
+  excludedMarkerWords:
+    displayName: Exclude markers containing these words
+    description: Comma separated list of words to exclude
+    type: STRING
+  matchFunscripts:
+    displayName: Match funscripts
+    type: BOOLEAN
+  overwriteMarkers:
+    displayName: Overwrite Markers
+    type: BOOLEAN
+  mergeMarkers:
+    displayName: Merge Markers
+    type: BOOLEAN
+
 hooks:
   - name: Add Marker to Scene
     description: Makes Markers checking against timestamp.trade
@@ -61,6 +81,10 @@ tasks:
     description: Submit scenes with a eroscripts.com forum post
     defaultArgs:
       mode: submitEroscriptScene
+  - name: "Submit Scenes with a funscript"
+    description: Submit scenes with a funscript
+    defaultArgs:
+      mode: submitInteractiveScene
   - name: "Sync"
     description: Get markers for all scenes with a stashid
     defaultArgs:
@@ -69,7 +93,7 @@ tasks:
     description: reprocess scenes with a timestamp.trade url
     defaultArgs:
       mode: reprocessScene
-  - name: "Re-process All"
+  - name: "Process All"
     description: reprocess all scenes with any stash-box id
     defaultArgs:
       mode: processAll
@@ -81,3 +105,8 @@ tasks:
     description: get gallery info from timestamp.trade
     defaultArgs:
       mode: processGallery
+  - name: "Index Funscript "
+    description: scan for funscript files to be matched and submitted
+    defaultArgs:
+      mode: indexFunscripts
+


### PR DESCRIPTION
A few more features, funscripts matching, excluding markers with matching strings and adding a string to new markers.

Indexing funscripts is done with a task creating a database with the funscript path and a md5 of the script. Submitting funscripts is done by the submit tasks. On query a list of funscript hashes are returned by the api and if thre is a matching script it will copy the file to the correct name for stash to match it.

Added an option to exclude markers that contain a string.

Added an option to add the [Timestamp] tag to markers the plugin creates.

Added an option to add the string [TsTrade] to markers eg "[TsTrade] marker name".

And bugfixes