### PR TITLE
Fix syntax error in timestampTrade.py

### DIFF
--- a/plugins/timestampTrade/timestampTrade.py
+++ b/plugins/timestampTrade/timestampTrade.py
@@ -66,7 +66,7 @@ def processSceneTimestamTrade(s):
                                 marker["primary_tag"] = m["name"]
 
                             if settings["addTsTradeTitle"]:
-                                marker["title"] = f"[TsTrade] {m["name"]}"
+                                marker["title"] = f"[TsTrade] {m['name']}"
 
                             # check for markers with a zero length title, skip adding
                             if len(marker["primary_tag"]) == 0:


### PR DESCRIPTION
This line leads to an syntax error: "unmatched '['" due to the usage of double quotes for both the f-string and the inner dictionary key.
The proposed solution fixes that.