### PR TITLE
Adding a new plugin audio-transcodes.

### DIFF
--- a/plugins/audio-transcodes/audio-transcodes.py
+++ b/plugins/audio-transcodes/audio-transcodes.py
@@ -1,0 +1,78 @@
+import stashapi.log as log
+from stashapi.stashapp import StashInterface
+import sys
+import json
+from pathlib import Path
+import os
+
+settings = {"hash_type": "oshash", "transcodes_dir": "/generated/transcodes/"}
+
+
+def run_ffmpeg(file, hash):
+    dest = Path(settings["transcodes_dir"]) / "transcodes" / str(hash + ".mp4")
+    if not dest.exists():
+        log.debug(
+            "running ffmpeg on %s to generate %s"
+            % (
+                file,
+                dest,
+            )
+        )
+        command = (
+            "ffmpeg -f lavfi -i color=c=blue:s=1280x720 -i %s  -shortest -fflags +shortest %s"
+            % (file, dest)
+        )
+        log.debug("about to run command: %s " % (command,))
+        os.system(command)
+    else:
+        log.debug(
+            "transcode already exists %s - %s"
+            % (
+                dest,
+                file,
+            )
+        )
+
+
+def processScene(s):
+    for f in s["files"]:
+        if f["width"] == 0:
+            log.debug("needs to transcode")
+            for h in f["fingerprints"]:
+                if h["type"] == settings["hash_type"]:
+                    file = f["path"]
+                    hash = h["value"]
+                    run_ffmpeg(file, hash)
+
+
+def processAll():
+    scenes = stash.find_scenes(
+        f={"resolution": {"modifier": "LESS_THAN", "value": "VERY_LOW"}}
+    )
+    for s in scenes:
+        processScene(s)
+
+
+json_input = json.loads(sys.stdin.read())
+
+FRAGMENT_SERVER = json_input["server_connection"]
+stash = StashInterface(FRAGMENT_SERVER)
+config = stash.get_configuration()
+
+log.debug(config)
+settings["transcodes_dir"] = config["general"]["generatedPath"]
+settings["hash_type"] = config["general"]["videoFileNamingAlgorithm"].lower()
+log.debug(settings)
+
+if "mode" in json_input["args"]:
+    PLUGIN_ARGS = json_input["args"]["mode"]
+    log.debug(json_input)
+    if "processScenes" == PLUGIN_ARGS:
+        processAll()
+
+elif "hookContext" in json_input["args"]:
+    _id = json_input["args"]["hookContext"]["id"]
+    _type = json_input["args"]["hookContext"]["type"]
+    if _type == "Scene.Create.Post":
+        scene = stash.find_scene(_id)
+        processScene(scene)

--- a/plugins/audio-transcodes/audio-transcodes.yml
+++ b/plugins/audio-transcodes/audio-transcodes.yml
@@ -1,0 +1,18 @@
+name: audio-transcodes
+description: Generate a transcode video from an audio file
+version: 0.1
+url: https://github.com/stashapp/CommunityScripts/
+exec:
+  - python
+  - "{pluginDir}/audio-transcodes.py"
+interface: raw
+hooks:
+  - name: process audio
+    description: transcode audio files on scan
+    triggeredBy:
+      - Scene.Create.Post
+tasks:
+  - name: "Process All"
+    description: transcode audio to video on all audio files
+    defaultArgs:
+      mode: processScenes


### PR DESCRIPTION
If there is an audio file (width and height is 0), generate a transcode.
This will convert the audio file to a video with a solid blue colour.
If a transcode file is found for the scene it will use that instead of the original file.
This is a file typically in /generated/transcodes/ohash.mp4 or /generated/transcodes/md5.mp4.
This allows the normal video player to be used.