### PR TITLE
Refactor URL detection logic to match sites

### DIFF
--- a/userscripts/StashDB_Submission_Helper/stashdb_submission_helper.user.js
+++ b/userscripts/StashDB_Submission_Helper/stashdb_submission_helper.user.js
@@ -160,83 +160,183 @@ function existingUrlObjects() {
   return urlObjects;
 }
 
+const urlPatterns = [
+  {
+    pattern:
+      /(^https?:\/\/(?:www\.)?adultfilmdatabase\.com\/(?:video|studio|actor)\/.+)\??/,
+    site: "AFDB",
+  },
+  // AllMyLinks
+  // APClips
+  // ashemale Tube
+  {
+    pattern: /(https?:\/\/www.babepedia.com\/babe\/[^?]+)\??/,
+    site: "Babepedia",
+  },
+  // Babes and Stars
+  {
+    pattern:
+      /(^https?:\/\/(?:www\.)?bgafd\.co\.uk\/(?:films|actresses)\/details.php\/id\/[^?]+)\??/,
+    site: "BGAFD",
+  },
+  {
+    pattern: /(https?:\/\/www.boobpedia.com\/boobs\/[^?]+)\??/,
+    site: "Boobpedia",
+  },
+  // CamSoda
+  // Chaturbate
+  // Clips4Sale
+  // Cocksuckers Guide
+  {
+    pattern: /(https?:\/\/www.data18.com\/[^?]+)\??/,
+    site: "DATA18",
+  },
+  // dbNaked
+  // DefineFetish
+  // DMM / FANZA
+  {
+    pattern:
+      /(^https?:\/\/(?:www\.)?egafd\.com\/(?:films|actresses)\/details.php\/id\/[^?]+)\??/,
+    site: "EGAFD",
+  },
+  {
+    pattern: /(https?:\/\/(www\.)?eurobabeindex.com\/sbandoindex\/.*?.html)/,
+    site: "Eurobabeindex",
+  },
+  // EuroPornstar
+  {
+    pattern: /(^https?:\/\/(?:www.)?facebook\.com\/[^?]+)/,
+    site: "Facebook",
+  },
+  // Fancentro
+  // FansDB
+  // Fansly
+  {
+    pattern: /(https?:\/\/www.freeones.com\/[^/?]+)\??/,
+    site: "FreeOnes",
+  },
+  {
+    pattern: /^https:\/\/gayeroticvideoindex\.com\/performer\/\d+$/,
+    site: "GEVI",
+  },
+  // GravureFit
+  {
+    pattern: /(https?:\/\/www.iafd.com\/[^?]+)\??/,
+    site: "IAFD",
+  },
+  // Idol Erotic
+  {
+    pattern: /(^https?:\/\/(?:www\.)?imdb\.com\/(?:name|title)\/[^?]+)\/?/,
+    site: "IMDB",
+  },
+  {
+    pattern: /(https?:\/\/www.indexxx.com\/[^?]+)\??/,
+    site: "Indexxx",
+  },
+  {
+    pattern: /(https?:\/\/www.instagram.com\/[^/?]+)\??/,
+    site: "Instagram",
+  },
+  // iWantClips
+  // JustFor.Fans
+  // Kick
+  // Linktree
+  // Lnk.Bio
+  // LoyalFans
+  {
+    pattern: /(https?:\/\/www.manyvids.com\/[^?]+)\??/,
+    site: "ManyVids",
+  },
+  // MFC Share
+  {
+    pattern: /(^https?:\/\/(?:www.)?minnano-av\.com\/actress\d+.html)/,
+    site: "Minnano-av",
+  },
+  // Modeling Agency
+  // Model Mayhem
+  // MSIN
+  // MyDirtyHobby
+  // MyFreeCams
+  {
+    pattern: /(^https?:\/\/(?:www.)?myspace\.com\/[^?]+)/,
+    site: "Myspace",
+  },
+  // Official Website
+  {
+    pattern: /(https?:\/\/onlyfans.com\/[^?]+)\??/,
+    site: "OnlyFans",
+  },
+  // Peach
+  // PMV Stash
+  // Pornhub
+  // Pornopedia
+  // PornPics
+  // PornTeenGirl
+  // R18.dev
+  // Reddit User
+  // Shemale Model Database
+  // Snapchat
+  // Sougouwiki
+  // Stripchat
+  {
+    pattern: /(https?:\/\/www.thenude.com\/[^?]+\.htm)/,
+    site: "theNude",
+  },
+  // ThePornDB
+  {
+    pattern: /(^https?:\/\/(?:www.)?tiktok\.com\/@[^?]+)/,
+    site: "TikTok",
+  },
+  // Twitch
+  {
+    pattern: /(https?:\/\/twitter.com\/[^?]+)\??/,
+    site: "Twitter",
+  },
+  {
+    pattern: /(https?:\/\/x.com\/[^?]+)\??/,
+    site: "Twitter",
+  },
+  // UViU
+  // WAPdB
+  // WAYBIG
+  {
+    pattern: /(^https?:\/\/(www\.)?wikidata.org\/wiki\/[^?]+)/,
+    site: "Wikidata",
+  },
+  // wikiFeet X
+  {
+    pattern: /(^https?:\/\/(?:\w+\.)?wikipedia\.org\/wiki\/[^?]+)/,
+    site: "Wikipedia",
+  },
+  // Wikiporno
+  // XCITY
+  {
+    pattern: /(^https?:\/\/xslist\.org\/en\/model\/\d+\.html)/,
+    site: "XsList",
+  },
+  // XVideos
+  {
+    pattern:
+      /(^https?:\/\/(?:www.)?youtube\.com\/(?:c(?:hannel)?|user)\/[^?]+)/,
+    site: "YouTube",
+  },
+  {
+    pattern: /^https?:\/\/gayeroticvideoindex\.com\/performer\/\d+$/,
+    site: "GEVI",
+  },
+  {
+    pattern: /^https:\/\/www\.gaybabeindex\.com\/[^?]+$/,
+    site: "GBI",
+  },
+];
 function urlSite(url) {
-  let site;
-  if (
-    /(^https?:\/\/(?:www\.)?adultfilmdatabase\.com\/(?:video|studio|actor)\/.+)\??/.test(
-      url
-    )
-  ) {
-    site = "AFDB";
-  } else if (/(https?:\/\/www.babepedia.com\/babe\/[^?]+)\??/.test(url)) {
-    site = "Babepedia";
-  } else if (
-    /(^https?:\/\/(?:www\.)?bgafd\.co\.uk\/(?:films|actresses)\/details.php\/id\/[^?]+)\??/.test(
-      url
-    )
-  ) {
-    site = "BGAFD";
-  } else if (/(https?:\/\/www.boobpedia.com\/boobs\/[^?]+)\??/.test(url)) {
-    site = "Boobpedia";
-  } else if (/(https?:\/\/www.data18.com\/[^?]+)\??/.test(url)) {
-    site = "DATA18";
-  } else if (
-    /(^https?:\/\/(?:www\.)?egafd\.com\/(?:films|actresses)\/details.php\/id\/[^?]+)\??/.test(
-      url
-    )
-  ) {
-    site = "EGAFD";
-  } else if (
-    /(https?:\/\/(www\.)?eurobabeindex.com\/sbandoindex\/.*?.html)/.test(url)
-  ) {
-    site = "Eurobabeindex";
-  } else if (/(^https?:\/\/(?:www.)?facebook\.com\/[^?]+)/.test(url)) {
-    site = "Facebook";
-  } else if (/(https?:\/\/www.freeones.com\/[^/?]+)\??/.test(url)) {
-    site = "FreeOnes";
-  } else if (/(https?:\/\/www.iafd.com\/[^?]+)\??/.test(url)) {
-    site = "IAFD";
-  } else if (
-    /(^https?:\/\/(?:www\.)?imdb\.com\/(?:name|title)\/[^?]+)\/?/.test(url)
-  ) {
-    site = "IMDB";
-  } else if (/(https?:\/\/www.indexxx.com\/[^?]+)\??/.test(url)) {
-    site = "Indexxx";
-  } else if (/(https?:\/\/www.instagram.com\/[^/?]+)\??/.test(url)) {
-    site = "Instagram";
-  } else if (/(https?:\/\/www.manyvids.com\/[^?]+)\??/.test(url)) {
-    site = "ManyVids";
-  } else if (
-    /(^https?:\/\/(?:www.)?minnano-av\.com\/actress\d+.html)/.test(url)
-  ) {
-    site = "Minnano-av";
-  } else if (/(^https?:\/\/(?:www.)?myspace\.com\/[^?]+)/.test(url)) {
-    site = "Myspace";
-  } else if (/(https?:\/\/onlyfans.com\/[^?]+)\??/.test(url)) {
-    site = "OnlyFans";
-  } else if (/(https?:\/\/www.thenude.com\/[^?]+\.htm)/.test(url)) {
-    site = "theNude";
-  } else if (/(^https?:\/\/(?:www.)?tiktok\.com\/@[^?]+)/.test(url)) {
-    site = "TikTok";
-  } else if (/(https?:\/\/twitter.com\/[^?]+)\??/.test(url)) {
-    site = "Twitter";
-  } else if (/(^https?:\/\/(www\.)?wikidata.org\/wiki\/[^?]+)/.test(url)) {
-    site = "Wikidata";
-  } else if (/(^https?:\/\/(?:\w+\.)?wikipedia\.org\/wiki\/[^?]+)/.test(url)) {
-    site = "Wikipedia";
-  } else if (/(^https?:\/\/xslist\.org\/en\/model\/\d+\.html)/.test(url)) {
-    site = "XsList";
-  } else if (
-    /(^https?:\/\/(?:www.)?youtube\.com\/(?:c(?:hannel)?|user)\/[^?]+)/.test(
-      url
-    )
-  ) {
-    site = "YouTube";
-  } else {
-    return;
+  for (const { pattern, site } of urlPatterns) {
+    if (pattern.test(url)) {
+      return site;
+    }
   }
 
-  return site;
+  return "Studio Profile";
 }
 
 function siteMatch(url, selections) {


### PR DESCRIPTION
- Change the original if-else chain to iterate through the urlPatterns array
- Each urlPattern object contains pattern and site attributes
- Use regular expressions to test the URL and return the corresponding site name
- Added regular expression matching rules for some additional sites
- Set "Studio Profile" as the default return value for the urlSite().