### PR TITLE
Resolve Syntax Error for TimeStamp Trade

### DIFF
--- a/plugins/timestampTrade/timestampTrade.py
+++ b/plugins/timestampTrade/timestampTrade.py
@@ -66,7 +66,7 @@ def processSceneTimestamTrade(s):
                                 marker["primary_tag"] = m["name"]
 
                             if settings["addTsTradeTitle"]:
-                                marker["title"] = f"[TsTrade] {m["name"]}"
+                                marker["title"] = f"[TsTrade] {m['name']}"
 
                             # check for markers with a zero length title, skip adding
                             if len(marker["primary_tag"]) == 0:


### PR DESCRIPTION
Changing use of double quote to single quote for Dict Call inside formatted string to resolve #447 