### PR TITLE
[Hot Cards] Add missing popstate event listener

### DIFF
--- a/plugins/hotCards/hotCards.yml
+++ b/plugins/hotCards/hotCards.yml
@@ -1,6 +1,6 @@
 name: Hot Cards
 description: Adds custom styling to card elements that match a Tag ID or a Rating Threshold.
-version: 1.2.0
+version: 1.2.1
 url: https://github.com/stashapp/CommunityScripts/tree/main/plugins/hotCards
 # requires: CommunityScriptsUILibrary
 ui:

--- a/plugins/hotCards/utils/helpers.js
+++ b/plugins/hotCards/utils/helpers.js
@@ -85,6 +85,10 @@ function overrideHistoryMethods(callback) {
       return result;
     };
   });
+
+  window.addEventListener("popstate", function () {
+    callback();
+  });
 }
 
 /** Path Change Listener */


### PR DESCRIPTION
This ensures 'activeHotCardTypes' is cleared when the user navigates backwards, allowing 'createAndInsertHotCards' to be run when there is the same type of hot card active in two subsequent navigations.