### PR TITLE
Update scenePageRememberStates.yml

### DIFF
--- a/plugins/scenePageRememberStates/scenePageRememberStates.yml
+++ b/plugins/scenePageRememberStates/scenePageRememberStates.yml
@@ -6,4 +6,4 @@ ui:
   requires:
     - CommunityScriptsUILibrary
   javascript:
-    - scenesPageRememberStates.js
+    - scenePageRememberStates.js


### PR DESCRIPTION
The plugin doesn't work because of a typo:

```
error serving file /config/plugins/community/scenePageRememberStates/scenesPageRememberStates.js: open /config/plugins/community/scenePageRememberStates/scenesPageRememberStates.js: no such file or directory
```