### PR TITLE
[tagSceneswithPerfTags] add check before processing scene

### DIFF
--- a/plugins/tagScenesWithPerfTags/tagScenesWithPerfTags.py
+++ b/plugins/tagScenesWithPerfTags/tagScenesWithPerfTags.py
@@ -63,8 +63,10 @@ if "mode" in json_input["args"]:
 elif "hookContext" in json_input["args"]:
     id = json_input["args"]["hookContext"]["id"]
     if (
-        json_input["args"]["hookContext"]["type"] == "Scene.Update.Post"
-        or "Scene.Create.Post"
+        (
+            json_input["args"]["hookContext"]["type"] == "Scene.Update.Post"
+                or "Scene.Create.Post"
+        ) and len(json_input["args"]["hookContext"]["inputFields"]) > 2
     ):
         scene = stash.find_scene(id)
         processScene(scene)


### PR DESCRIPTION
tagScenesWithPrefTags has a problem where it comes in a loop of calling itself.

This checks for the length of the update keys, which would be greater than 2 when manually updating a scene. But when the plugin updates it, it is only 2 ("ids", "tag_ids").

This should also fix #396