### PR TITLE
Uses dict.get() to avoid KeyError in TPDBMarkers plugin

### DIFF
--- a/plugins/TPDBMarkers/tpdbMarkers.py
+++ b/plugins/TPDBMarkers/tpdbMarkers.py
@@ -38,7 +38,7 @@ def processScene(scene):
                         log.info("Saving markers")
                         mp.import_scene_markers(stash, markers, scene["id"], 15)
                     # skip if there is already a movie linked
-                    if settings["createMovieFromScene"] and len(scene["movies"]) ==0:
+                    if settings["createMovieFromScene"] and len(scene.get("movies", [])) == 0:
                         movies=[]
                         for m in data["movies"]:
                            movie=processMovie(m)


### PR DESCRIPTION
When the `'movies'` key doesn't exist in the `scene` dictionary, a KeyError is thrown.

https://github.com/stashapp/CommunityScripts/blob/3dc70057e9b5a023842ed36ca5e8dcba25e0db33/plugins/TPDBMarkers/tpdbMarkers.py#L41

Instead, we can use the `get()` method, which will return `None` (or other default value) if the key does not exist, instead of raising a KeyError.

`len(scene["movies"])  >>  len(scene.get("movies", []))`

----

Resolves #440. Resolves #455.