### PR TITLE
[themeSwitch] css loading fails with error

### DIFF
--- a/plugins/themeSwitch/themeSwitchMain.js
+++ b/plugins/themeSwitch/themeSwitchMain.js
@@ -248,7 +248,7 @@
     console.log(key, path);
     const styleSheet = document.createElement("link");
     const serverURL =
-      window.Location.origin +
+      window.location.origin +
         document.querySelector("base")?.getAttribute("href") ?? "/";
     styleSheet.setAttribute(
       "href",


### PR DESCRIPTION
Fixes #390

Sometimes the css isn't loaded correctly cause `window.Location.origin` should be lowercase