### PR TITLE
Fix basic `pathParser` plugin functionality

### DIFF
--- a/plugins/pathParser/pathParser.js
+++ b/plugins/pathParser/pathParser.js
@@ -322,6 +322,7 @@ function testRule(pattern, parts) {
   }
 
   var matchedParts = [];
+  var subMatches;
   for (var i = 0; i < pattern.length; i++) {
     if ((subMatches = testPattern(pattern[i], parts[i])) == null) {
       return null;

--- a/plugins/pathParser/pathParser.js
+++ b/plugins/pathParser/pathParser.js
@@ -653,7 +653,7 @@ function tryGetTag(tag) {
 
   var result = gql.Do(query, variables);
   if (!result.findTags || result.findTags.count == 0) {
-    return;
+    return null;
   }
 
   return result.findTags.tags[0].id;


### PR DESCRIPTION
Tried to configure the plugin and went down a debugging rabbit hole. These are the two bugs I've found so far. The tag creation and test tasks now work. Haven't got as far as testing the actual hook/run task functions yet.

I expect there are more dragons lurking in this code...