### PR TITLE
Parse All Galleries for date

### DIFF
--- a/plugins/DateParser/date_parser.py
+++ b/plugins/DateParser/date_parser.py
@@ -30,7 +30,7 @@ def parse_date_candidate(string):
         g3 = match.group(3)
         temp = parse(g1 + " " + g2 + " " + g3)
         if temp:
-            result =temp.strftime("%Y-%m-%d")
+            result = temp.strftime("%Y-%m-%d")
     return result
 
 

--- a/plugins/DateParser/date_parser.py
+++ b/plugins/DateParser/date_parser.py
@@ -52,7 +52,6 @@ def find_date_for_galleries():
         
         if "folder" in gallery and gallery["folder"]:
             if "path" in gallery["folder"] and gallery["folder"]["path"]:
-                pass
                 if candidate := parse_date_candidate(gallery["folder"]["path"]):
                     acceptableDate = candidate
         

--- a/plugins/DateParser/date_parser.py
+++ b/plugins/DateParser/date_parser.py
@@ -23,13 +23,15 @@ def main():
 
 
 def parse_date_candidate(string):
+    result = None
     for match in pattern.finditer(string):
         g1 = match.group(1)
         g2 = match.group(2)
         g3 = match.group(3)
         temp = parse(g1 + " " + g2 + " " + g3)
         if temp:
-            return temp.strftime("%Y-%m-%d")
+            result =temp.strftime("%Y-%m-%d")
+    return result
 
 
 def find_date_for_galleries():

--- a/plugins/DateParser/date_parser.yml
+++ b/plugins/DateParser/date_parser.yml
@@ -1,6 +1,6 @@
 name: Gallery Date Parser
 description: Find date in path or filename and add it to the gallery
-version: 0.2.1
+version: 0.3.0
 exec:
   - python
   - "{pluginDir}/date_parser.py"


### PR DESCRIPTION
- Break out the date parsing to a separate function.
- Expand gallery search to more than single file zip galleries.
- Also scan the gallery's folder path if available.

The final valid parsed date of the files, then the gallery folder will be taken as the gallery's date. This will preserve the previous behavior of single file zip galleries, as there will be only one path to ever consider.