### PR TITLE
# Update TPDB Markers Plugin to Use find_groups()

### DIFF
--- a/plugins/TPDBMarkers/tpdbMarkers.py
+++ b/plugins/TPDBMarkers/tpdbMarkers.py
@@ -106,7 +106,7 @@ def processMovie(m):
     log.debug(m)
     log.debug(m.keys())
     # check if the movie exists with the url, then match to the scene
-    sm = stash.find_movies(
+    sm = stash.find_groups(
       f={
         "url": {
           "modifier": "EQUALS",
@@ -118,7 +118,7 @@ def processMovie(m):
     if len(sm) >0:
         return sm[0]
     # find the movie by name
-    sm=stash.find_movies(q=m['title'])
+    sm=stash.find_groups(q=m['title'])
     for mov in sm:
         if mov['name']==m['title']:
           return mov


### PR DESCRIPTION
## Description
This PR updates the TPDB Markers plugin to use the newer `find_groups()` method instead of the deprecated `find_movies()` method. This change resolves the deprecation warning while maintaining the same functionality.

`Warning 
[Plugin / The Porn DB Markers] find_movies() is depracated use find_gruops()`

## Changes Made
- Replaced `stash.find_movies()` with `stash.find_groups()` in the `processMovie()` function
- Updated both instances where the method was used:
  1. When checking for existing movies by URL
  2. When searching for movies by title

## Testing
The functionality remains the same, but now uses the recommended API method. The plugin will continue to:
- Process TPDB markers
- Create and associate movies with scenes
- Handle all existing features without the deprecation warning

## Related Issue
Fixes deprecation warning.