### PR TITLE
[fix] [Timestamp Trade] Use context manager with connection to cleanup and reduce db locking

### DIFF
--- a/plugins/timestampTrade/timestampTrade.yml
+++ b/plugins/timestampTrade/timestampTrade.yml
@@ -1,6 +1,6 @@
 name: Timestamp Trade
 description: Sync Markers with timestamp.trade, a new database for sharing markers.
-version: 0.8
+version: 0.8.1
 url: https://github.com/stashapp/CommunityScripts/
 exec:
   - python


### PR DESCRIPTION
This is a copy of #533 since it was closed without merge.
It wraps the connections to prevent connection when DB is in use.

- closes #310 
- closes #463
- closes #491 