### PR TITLE
[tagScenesWithPerfTags] Add check if key exists

### DIFF
--- a/plugins/tagScenesWithPerfTags/tagScenesWithPerfTags.py
+++ b/plugins/tagScenesWithPerfTags/tagScenesWithPerfTags.py
@@ -72,15 +72,14 @@ if "mode" in json_input["args"]:
     PLUGIN_ARGS = json_input["args"]["mode"]
     if "processAll" in PLUGIN_ARGS:
         processAll()
-
-
 elif "hookContext" in json_input["args"]:
     id = json_input["args"]["hookContext"]["id"]
     if (
         (
             json_input["args"]["hookContext"]["type"] == "Scene.Update.Post"
                 or "Scene.Create.Post"
-        ) and len(json_input["args"]["hookContext"]["inputFields"]) > 2
+        ) and "inputFields" in json_input["args"]["hookContext"]
+        and len(json_input["args"]["hookContext"]["inputFields"]) > 2
     ):
         scene = stash.find_scene(id)
         processScene(scene)

--- a/plugins/tagScenesWithPerfTags/tagScenesWithPerfTags.yml
+++ b/plugins/tagScenesWithPerfTags/tagScenesWithPerfTags.yml
@@ -1,6 +1,6 @@
 name: Tag Scenes From Performer Tags
 description: tags scenes with performer tags.
-version: 0.2
+version: 0.2.1
 exec:
   - python
   - "{pluginDir}/tagScenesWithPerfTags.py"


### PR DESCRIPTION
This checks for `inputFields` on `hookContext`. This prevents an error that happened when scanning scenes for the first time.