### PR TITLE
[plugins/miscTags] VRCompanionTags Not running

### DIFF
--- a/plugins/miscTags/miscTags.py
+++ b/plugins/miscTags/miscTags.py
@@ -9,7 +9,7 @@ per_page = 100
 skip_tag = "[MiscTags: Skip]"
 
 # Defaults if nothing has changed in the stash ui
-settings = {"addStashVrCompanionTags": False,
+settings = {"addStashVRCompanionTags": False,
             "addVRTags": False,
             "addSoloTags": True,
             "addThreesomeTags": True,
@@ -52,7 +52,7 @@ def processScene(scene):
     if tags_cache[skip_tag] not in [x["id"] for x in scene["tags"]]:
         tags = []
         update = False
-        if settings["addStashVrCompanionTags"]:
+        if settings["addStashVRCompanionTags"]:
             processStashVRCompanionTags(scene, tags)
             log.debug(tags)
         if settings["addVRTags"]:

--- a/plugins/miscTags/miscTags.yml
+++ b/plugins/miscTags/miscTags.yml
@@ -1,6 +1,6 @@
 name: Misc Tags
 description: Add extra tags for VR and other ues
-version: 0.5
+version: 0.4.1
 url: https://github.com/stashapp/CommunityScripts/
 exec:
   - python

--- a/plugins/miscTags/miscTags.yml
+++ b/plugins/miscTags/miscTags.yml
@@ -1,6 +1,6 @@
 name: Misc Tags
 description: Add extra tags for VR and other ues
-version: 0.4
+version: 0.5
 url: https://github.com/stashapp/CommunityScripts/
 exec:
   - python


### PR DESCRIPTION
Was never taging based on VRCompanionTags as the setting name is case sensitive.