### PR TITLE
[timestampTrade] [tpdbMarkers] replace "url" with "urls"

### DIFF
--- a/plugins/TPDBMarkers/tpdbMarkers.py
+++ b/plugins/TPDBMarkers/tpdbMarkers.py
@@ -131,7 +131,7 @@ def processMovie(m):
        'synopsis': m['description'],
        'front_image': m['image'],
        'back_image': m['back_image'],
-       'url': m['url'],
+       'urls': [m['url']],
     }
     if m['site']:
         studio=stash.find_studio(m['site'],create=True)

--- a/plugins/timestampTrade/timestampTrade.py
+++ b/plugins/timestampTrade/timestampTrade.py
@@ -257,7 +257,7 @@ def processSceneTimestamTrade(s):
                                                     if new_movie["date"] == "1-01-01":
                                                         new_movie["date"] = None
                                                     if not movie_scrape["urls"]:
-                                                        new_movie["url"] = u["url"]
+                                                        new_movie["urls"] = u["url"]
                                                     if movie_scrape["studio"]:
                                                         new_movie["studio_id"] = (
                                                             movie_scrape["studio"][
@@ -268,6 +268,8 @@ def processSceneTimestamTrade(s):
                                                         new_movie["urls"] = [
                                                             x["url"] for x in m["urls"]
                                                         ]
+                                                        if hasattr(new_movie, "url"):
+                                                            delattr(new_movie, "url")
                                                     log.debug(
                                                         "new movie: %s" % (new_movie,)
                                                     )
@@ -283,7 +285,7 @@ def processSceneTimestamTrade(s):
                                             "date": m["release_date"],
                                         }
                                         if len(m["urls"]) > 0:
-                                            new_movie["url"] = m["urls"][0]["url"]
+                                            new_movie["urls"] = m["urls"][0]["url"]
 
                                         log.debug("new movie: %s" % (new_movie,))
                                         nm = stash.create_movie(new_movie)


### PR DESCRIPTION
Use `urls` instead of `url` so both plugins don't throw/exit when the create_movie to create_group shim in recent stashapi version is used.