### PR TITLE
bulkImageScrape plugin now uses generator and paging to iterate images

### DIFF
--- a/plugins/bulkImageScrape/BulkImageScrape.yml
+++ b/plugins/bulkImageScrape/BulkImageScrape.yml
@@ -1,6 +1,6 @@
 name: Bulk Image Scrape
 description: Apply an image scraper to all images
-version: 0.3
+version: 0.3.1
 url: https://github.com/stashapp/CommunityScripts/
 exec:
   - python
@@ -29,6 +29,9 @@ settings:
   ExcludeOrganized:
     displayName: Exclude images that are set as organized (default is to include)
     type: BOOLEAN
+  SkipEntriesNum:
+    displayName: number of entries to skip over (mostly for rerunning after an error on large collections)
+    type: NUMBER
   
 tasks:
   - name: "Bulk Image Scrape"


### PR DESCRIPTION
The bulkImageScrape plugin used to request data of all images in the library in one big query at the beginning, which got really problematic on a very large library (like 250K images), leading to stash to first consume all the memory it can get and then die.

The new behavior uses page queries and a generator to process images in batches of 100.

I also added a plugin setting to skip a set number of entries, this was useful for runs that die midway through (for example due to scraper issues, etc).

I have no idea about the version number, so I just bumped it to a .1