### PR TITLE
[StashRandomButton] Consistent Randomization on All Pages

### DIFF
--- a/plugins/StashRandomButton/README.md
+++ b/plugins/StashRandomButton/README.md
@@ -40,8 +40,43 @@ Adds a "Random" button to the Stash UI, letting you instantly jump to a random s
    - The button should appear on those pages.
 
 ## Usage
-Click the "Random" button in the navigation bar to jump to a random entity (scene, image, performer, studio, group, tag, or gallery) depending on your current page.
-  - On internal entity pages (e.g., performer, studio, group, tag, gallery), the button picks a random scene or image from inside that entity.
+
+Click the "Random" button in the navigation bar to instantly jump to a random item, with behavior depending on your current page:
+
+- **Scenes:**
+  - On the main scenes page, the button selects a random scene from all scenes in your library.
+  - On a performer, studio, tag, or group *scenes* page, it picks a random scene **from within that entity**.
+  - When viewing a scene's detail page, clicking "Random" again selects a random scene from **all scenes** (not just from the previous filter).
+
+- **Groups:**
+  - On the main groups page, the button picks a random group.
+  - Inside a group (group's scenes page), it selects a random scene from within that group.
+
+- **Galleries & Images:**
+  - On the main galleries page, the button picks a random gallery.
+  - Inside a gallery (gallery's page), it selects a random image from that gallery.
+  - When viewing an individual image (image detail page), the button selects a random image from **all images in the database**, not just from the current gallery.
+
+- **Performers:**
+  - On the main performers page, it picks a random performer.
+  - Inside a performer's page (performer's scenes), it selects a random scene from that performer.
+  - When viewing a scene's detail page, clicking "Random" again picks a random scene from **all scenes**.
+
+- **Studios:**
+  - On the main studios page, the button picks a random studio.
+  - Inside a studio's page (studio's scenes), it selects a random scene from that studio.
+  - When viewing a scene's detail page, clicking "Random" again selects a random scene from **all scenes**.
+
+- **Tags:**
+  - On the main tags page, it picks a random tag.
+  - Inside a tag's page (tag's scenes), it selects a random scene from that tag.
+  - When viewing a scene's detail page, clicking "Random" again picks a random scene from **all scenes**, regardless of tag.
+
+---
+
+**Tip:** The Random button always selects from the *full library* when you are on a detail (scene or image) page, regardless of how you navigated there.
+
+---
 
 ## Requirements
 - Stash version v0.27.2 or higher.
@@ -51,4 +86,11 @@ Click the "Random" button in the navigation bar to jump to a random entity (scen
 - Edit `random-button.js` to customize and reload plugins in Stash.
 
 ## Changelog
+- 2.0.1:
+  - The Random button now works on scene and image detail pages: when viewing an individual scene or image, clicking "Random" selects a random scene or image from the entire database.
+  - Improved context awareness for the Random button on all major Stash entities (scenes, performers, studios, tags, groups, galleries, images).
+  - When inside a group, tag, studio, performer, or gallery, the button picks a random scene or image from within that entity.
+  - When on a group, tag, studio, performer, or gallery detail page (not listing scenes/images), the Random button selects a random group, tag, studio, performer, or gallery respectively.
+  - Updated documentation.
 - 2.0.0: Major upgrade! Now supports random navigation for performers, studios, groups, tags, galleries, and images (global and internal).
+- 1.1.0: Initial public release with support for random scenes.

--- a/plugins/StashRandomButton/README.md
+++ b/plugins/StashRandomButton/README.md
@@ -1,13 +1,23 @@
 # Stash Random Button Plugin
 
-https://discourse.stashapp.cc/t/randombutton/1809
+[Plugin thread on Discourse](https://discourse.stashapp.cc/t/randombutton/1809)
 
-Adds a "Random" button to the image & scenes page to quickly navigate to a random scene.
+Adds a "Random" button to the Stash UI, letting you instantly jump to a random scene, image, performer, studio, group, tag, or gallery—including random "internal" navigation (e.g. a random scene inside a studio).
 
 ## Features
-- Adds a "Random" button to the Stash UI.
-- Selects a random scene via GraphQL query.
+
+- Adds a "Random" button to the Stash UI navigation bar.
+- Supports random navigation for:
+  - **Scenes** (global and within performer, studio, tag, group)
+  - **Images** (global and within a gallery)
+  - **Performers** (global)
+  - **Studios** (global)
+  - **Groups** (global)
+  - **Tags** (global)
+  - **Galleries** (global)
 - Lightweight, no external dependencies.
+- Uses Stash's GraphQL API.
+- Simple, robust, and easy to maintain.
 
 ## Installation
 
@@ -30,7 +40,8 @@ Adds a "Random" button to the image & scenes page to quickly navigate to a rando
    - The button should appear on those pages.
 
 ## Usage
-Click the "Random" button in the navigation bar to jump to a random image or scene depending on the tab.
+Click the "Random" button in the navigation bar to jump to a random entity (scene, image, performer, studio, group, tag, or gallery) depending on your current page.
+  - On internal entity pages (e.g., performer, studio, group, tag, gallery), the button picks a random scene or image from inside that entity.
 
 ## Requirements
 - Stash version v0.27.2 or higher.
@@ -38,3 +49,6 @@ Click the "Random" button in the navigation bar to jump to a random image or sce
 ## Development
 - Written in JavaScript using the Stash Plugin API.
 - Edit `random-button.js` to customize and reload plugins in Stash.
+
+## Changelog
+- 2.0.0: Major upgrade! Now supports random navigation for performers, studios, groups, tags, galleries, and images (global and internal).

--- a/plugins/StashRandomButton/random_button.js
+++ b/plugins/StashRandomButton/random_button.js
@@ -105,7 +105,7 @@
     if (tagId) 
       return randomGlobal('Scene', 'scenes', '/scenes/', { tags: { value: [tagId], modifier: "INCLUDES_ALL" } });
 
-    let galleryId = getIdFromPath(/^\/galleries\/(\d+)$/); // SOLO si estamos en la página de galería
+    let galleryId = getIdFromPath(/^\/galleries\/(\d+)$/);
     if (galleryId)
       return randomGlobal('Image', 'images', '/images/', { galleries: { value: [galleryId], modifier: "INCLUDES_ALL" } });
 

--- a/plugins/StashRandomButton/random_button.js
+++ b/plugins/StashRandomButton/random_button.js
@@ -67,7 +67,7 @@
     const pathname = window.location.pathname.replace(/\/$/, '');
 
     // GLOBAL
-    if (pathname === '/scenes' || /^\/scenes\/\d+$/.test(pathname)) 
+    if (pathname === '/scenes' || pathname === '/' || pathname === '' || pathname === '/stats' || pathname === '/settings' || /^\/scenes\/\d+$/.test(pathname))  
       return randomGlobal('Scene', 'scenes', '/scenes/');
 
     if (pathname === '/images' || /^\/images\/\d+$/.test(pathname)) 

--- a/plugins/StashRandomButton/random_button.js
+++ b/plugins/StashRandomButton/random_button.js
@@ -67,7 +67,7 @@
     const pathname = window.location.pathname.replace(/\/$/, '');
 
     // GLOBAL
-    if (pathname === '/scenes' || pathname === '/' || pathname === '' || pathname === '/stats' || pathname === '/settings' || /^\/scenes\/\d+$/.test(pathname))  
+    if (pathname === '/scenes' || pathname === '/' || pathname === '' || pathname === '/stats' || pathname === '/settings' || pathname === '/scenes/markers' || /^\/scenes\/\d+$/.test(pathname))  
       return randomGlobal('Scene', 'scenes', '/scenes/');
 
     if (pathname === '/images' || /^\/images\/\d+$/.test(pathname)) 

--- a/plugins/StashRandomButton/random_button.js
+++ b/plugins/StashRandomButton/random_button.js
@@ -66,7 +66,7 @@
   async function randomButtonHandler() {
     const pathname = window.location.pathname.replace(/\/$/, '');
 
-    // GLOBAL: lista y detalle (images, scenes, etc)
+    // GLOBAL
     if (pathname === '/scenes' || /^\/scenes\/\d+$/.test(pathname)) 
       return randomGlobal('Scene', 'scenes', '/scenes/');
 
@@ -88,7 +88,7 @@
     if (pathname === '/galleries') 
       return randomGlobal('Gallery', 'galleries', '/galleries/');
 
-    // --- Internos ---
+    // Intern
     let studioId = getIdFromPath(/^\/studios\/(\d+)\/scenes/);
     if (studioId) 
       return randomGlobal('Scene', 'scenes', '/scenes/', { studios: { value: [studioId], modifier: "INCLUDES_ALL" } });

--- a/plugins/StashRandomButton/random_button.js
+++ b/plugins/StashRandomButton/random_button.js
@@ -66,29 +66,48 @@
   async function randomButtonHandler() {
     const pathname = window.location.pathname.replace(/\/$/, '');
 
-    if (pathname === '/scenes') return randomGlobal('Scene', 'scenes', '/scenes/');
-    if (pathname === '/performers') return randomGlobal('Performer', 'performers', '/performers/');
-    if (pathname === '/groups') return randomGlobal('Group', 'groups', '/groups/');
-    if (pathname === '/studios') return randomGlobal('Studio', 'studios', '/studios/');
-    if (pathname === '/tags') return randomGlobal('Tag', 'tags', '/tags/');
-    if (pathname === '/galleries') return randomGlobal('Gallery', 'galleries', '/galleries/');
-    if (pathname === '/images') return randomGlobal('Image', 'images', '/images/');
+    // GLOBAL: lista y detalle (images, scenes, etc)
+    if (pathname === '/scenes' || /^\/scenes\/\d+$/.test(pathname)) 
+      return randomGlobal('Scene', 'scenes', '/scenes/');
 
-    // --- INTERN ---
+    if (pathname === '/images' || /^\/images\/\d+$/.test(pathname)) 
+      return randomGlobal('Image', 'images', '/images/');
+
+    if (pathname === '/performers' || /^\/performers\/\d+$/.test(pathname)) 
+      return randomGlobal('Performer', 'performers', '/performers/');
+
+    if (pathname === '/studios' || /^\/studios\/\d+$/.test(pathname)) 
+      return randomGlobal('Studio', 'studios', '/studios/');
+
+    if (pathname === '/tags' || /^\/tags\/\d+$/.test(pathname)) 
+      return randomGlobal('Tag', 'tags', '/tags/');
+
+    if (pathname === '/groups' || /^\/groups\/\d+$/.test(pathname)) 
+      return randomGlobal('Group', 'groups', '/groups/');
+
+    if (pathname === '/galleries') 
+      return randomGlobal('Gallery', 'galleries', '/galleries/');
+
+    // --- Internos ---
     let studioId = getIdFromPath(/^\/studios\/(\d+)\/scenes/);
-    if (studioId) return randomGlobal('Scene', 'scenes', '/scenes/', { studios: { value: [studioId], modifier: "INCLUDES_ALL" } });
+    if (studioId) 
+      return randomGlobal('Scene', 'scenes', '/scenes/', { studios: { value: [studioId], modifier: "INCLUDES_ALL" } });
 
     let groupId = getIdFromPath(/^\/groups\/(\d+)\/scenes/);
-    if (groupId) return randomGlobal('Scene', 'scenes', '/scenes/', { groups: { value: [groupId], modifier: "INCLUDES_ALL" } });
+    if (groupId) 
+      return randomGlobal('Scene', 'scenes', '/scenes/', { groups: { value: [groupId], modifier: "INCLUDES_ALL" } });
 
     let performerId = getIdFromPath(/^\/performers\/(\d+)\/scenes/);
-    if (performerId) return randomGlobal('Scene', 'scenes', '/scenes/', { performers: { value: [performerId], modifier: "INCLUDES_ALL" } });
+    if (performerId) 
+      return randomGlobal('Scene', 'scenes', '/scenes/', { performers: { value: [performerId], modifier: "INCLUDES_ALL" } });
 
     let tagId = getIdFromPath(/^\/tags\/(\d+)\/scenes/);
-    if (tagId) return randomGlobal('Scene', 'scenes', '/scenes/', { tags: { value: [tagId], modifier: "INCLUDES_ALL" } });
+    if (tagId) 
+      return randomGlobal('Scene', 'scenes', '/scenes/', { tags: { value: [tagId], modifier: "INCLUDES_ALL" } });
 
-    let galleryId = getIdFromPath(/^\/galleries\/(\d+)/);
-    if (galleryId) return randomGlobal('Image', 'images', '/images/', { galleries: { value: [galleryId], modifier: "INCLUDES_ALL" } });
+    let galleryId = getIdFromPath(/^\/galleries\/(\d+)$/); // SOLO si estamos en la página de galería
+    if (galleryId)
+      return randomGlobal('Image', 'images', '/images/', { galleries: { value: [galleryId], modifier: "INCLUDES_ALL" } });
 
     alert('Not supported');
   }

--- a/plugins/StashRandomButton/random_button.js
+++ b/plugins/StashRandomButton/random_button.js
@@ -73,16 +73,16 @@
     if (pathname === '/images' || /^\/images\/\d+$/.test(pathname)) 
       return randomGlobal('Image', 'images', '/images/');
 
-    if (pathname === '/performers' || /^\/performers\/\d+$/.test(pathname)) 
+    if (pathname === '/performers') 
       return randomGlobal('Performer', 'performers', '/performers/');
 
-    if (pathname === '/studios' || /^\/studios\/\d+$/.test(pathname)) 
+    if (pathname === '/studios') 
       return randomGlobal('Studio', 'studios', '/studios/');
 
-    if (pathname === '/tags' || /^\/tags\/\d+$/.test(pathname)) 
+    if (pathname === '/tags') 
       return randomGlobal('Tag', 'tags', '/tags/');
 
-    if (pathname === '/groups' || /^\/groups\/\d+$/.test(pathname)) 
+    if (pathname === '/groups') 
       return randomGlobal('Group', 'groups', '/groups/');
 
     if (pathname === '/galleries') 

--- a/plugins/StashRandomButton/random_button.yml
+++ b/plugins/StashRandomButton/random_button.yml
@@ -1,7 +1,7 @@
 name: RandomButton
 description: Adds a button to quickly jump to a random scene, image, performer, studio, group, tag, or gallery, both on overview and internal entity pages.
-version: 2.0.0
-url: https://example.com
+version: 2.0.1
+url: https://github.com/stashapp/CommunityScripts/tree/main/plugins/StashRandomButton
 ui:
   requires: []
   javascript:

--- a/plugins/StashRandomButton/random_button.yml
+++ b/plugins/StashRandomButton/random_button.yml
@@ -1,6 +1,6 @@
 name: RandomButton
-description: Adds a button to quickly switch to a random scene or image on both overview and detail pages
-version: 1.1.0
+description: Adds a button to quickly jump to a random scene, image, performer, studio, group, tag, or gallery, both on overview and internal entity pages.
+version: 2.0.0
 url: https://example.com
 ui:
   requires: []


### PR DESCRIPTION
## Summary

This PR improves the behavior and usability of the Random button across Stash pages, making navigation more intuitive and predictable.

## How it works

- The Random button appears in the navigation bar on all main entity pages (scenes, images, performers, studios, groups, tags, galleries) and their internal pages (e.g. performer’s scenes, studio’s scenes, gallery’s images, etc).
- **Scenes:**  
  - On the main scenes page, it picks a random scene from all scenes.
  - On a performer/studio/tag/group *scenes* page, it picks a random scene from within that entity.
  - On an individual scene’s detail page, clicking Random always picks a random scene from **all scenes** (regardless of how you arrived at that scene).
- **Images and Galleries:**  
  - On the main galleries page, it picks a random gallery.
  - On a gallery’s page, it picks a random image from that gallery.
  - On an individual image’s detail page, clicking Random picks a random image from **all images** in the database (not just images from the same gallery).
- **Performers, Studios, Groups, Tags:** 
  - On a studio/tag, it picks a random scene from that studio/tag, not considering sub-studios/sub-tags or parent studios/tags. 
  - On the main page for each entity, it picks a random entity.
  - On their internal scenes page, it picks a random scene from that entity.
  - On a scene detail page, Random again picks from **all scenes**.


## Clarification

- When you are viewing an individual scene or image, the Random button will **always** select from the entire collection (all scenes or all images), and does **not** remember or limit itself to the tag, performer, studio, group, or gallery you came from.  

## Other notes

- Updated documentation and changelog.

---

**Let me know if you have any suggestions or feedback!**
