### PR TITLE
[imageGalleryNavigation] Initial commit.

### DIFF
--- a/plugins/imageGalleryNavigation/README.md
+++ b/plugins/imageGalleryNavigation/README.md
@@ -1,0 +1,12 @@
+# Image Gallery Navigation
+
+This plugin adds features for navigating between images within a Gallery from the Image details page. This is intended to make it easier to edit metadata on each Image in a Gallery one at a time without constantly having to go back and forth between the Gallery and Image page.
+
+This plugin currently adds two things to the Image details page:
+    - A line above the tabs in the left panel that indicates the current page and total number of pages in the current Gallery. The current image number can be changed to jump to a specific image within the Gallery.
+    - Buttons along the left/right side of the main Image display panel that allow moving to the previous/next image in the Gallery.
+
+In the case of Images that are in multiple Galleries, the Gallery being navigated is set by accessing an Images from the Gallery you want to navigate. Otherwise, if you navigate directly to an Image, the first Gallery the Image belongs to will be used as the basis for navigation.
+
+Known issues/limitations:
+    - Currently is hardcoded to always sort Images by title.

--- a/plugins/imageGalleryNavigation/imageGalleryNavigation.css
+++ b/plugins/imageGalleryNavigation/imageGalleryNavigation.css
@@ -1,0 +1,38 @@
+.imageGalleryNav-NavInput {
+  -moz-appearance: textfield;
+  width: 60px;
+}
+
+.imageGalleryNav-NavInput::-webkit-outer-spin-button,
+.imageGalleryNav-NavInput::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.imageGalleryNav-leftButton,
+.imageGalleryNav-rightButton {
+  position: absolute;
+  top: 0;
+  bottom: 120px;
+  width: 200px;
+  background: none;
+  border: none;
+  user-select: none;
+  opacity: 0;
+  font-size: 40px;
+  font-weight: bold;
+  z-index: 999;
+}
+
+.imageGalleryNav-leftButton:hover,
+.imageGalleryNav-rightButton:hover {
+  opacity: 0.6;
+}
+
+.imageGalleryNav-leftButton {
+  left: 15px;
+}
+
+.imageGalleryNav-rightButton {
+  right: 15px;
+}

--- a/plugins/imageGalleryNavigation/imageGalleryNavigation.js
+++ b/plugins/imageGalleryNavigation/imageGalleryNavigation.js
@@ -160,14 +160,14 @@
       .then((data) => data.findImages.images.map((item) => item.id));
   }
 
-  // Wait for video player to load on scene page.
+  // Wait for galleries page to load.
   csLib.PathElementListener(
     "/galleries/",
     ".image-card",
     setupGalleryImageLinks
   ); // PathElementListener is from cs-ui-lib.js
 
-  // Wait for video player to load on scene page.
+  // Wait for images page to load.
   csLib.PathElementListener(
     "/images/",
     ".image-container",

--- a/plugins/imageGalleryNavigation/imageGalleryNavigation.js
+++ b/plugins/imageGalleryNavigation/imageGalleryNavigation.js
@@ -1,0 +1,176 @@
+(async () => {
+  const localStorageGalleryKey = "imageGalleryNavigation-GalleryID";
+
+  // In order to handle scenarios where an image is in multiple galleries, capture ID of gallery the user is navigating from.
+  // If user navigates directly to an image URL and image is in multiple galleries, we will just use the first gallery in list.
+  // This may break if user jumps around in browser history, in which case we will fall back to basic scenario of assuming first gallery in list.
+  async function setupGalleryImageLinks() {
+    document.querySelectorAll("a[href*='/images/']").forEach(function (link) {
+      link.addEventListener("click", () => {
+        var galleryID = window.location.pathname.split("/")[2];
+        localStorage.setItem(localStorageGalleryKey, galleryID);
+      });
+    });
+  }
+
+  // On image page, get data about gallery (image's position within gallery, next/prev image IDs),
+  // add arrow buttons to page, and register arrow keypress handlers,
+  async function setupImageContainer() {
+    var imageID = window.location.pathname.split("/")[2];
+    var imageGalleries = await findImage(imageID);
+
+    if (imageGalleries != null && imageGalleries.length > 0) {
+      // Get first entry in galleries list.
+      var galleryID = imageGalleries[0];
+
+      // Check if there is a saved gallery ID and it is in gallery list. If true, use saved ID.
+      var savedGalleryId = localStorage.getItem(localStorageGalleryKey);
+      if (savedGalleryId != null && imageGalleries.includes(savedGalleryId)) {
+        galleryID = savedGalleryId;
+      } else {
+        localStorage.setItem(localStorageGalleryKey, galleryID);
+      }
+
+      // Get gallery image list.
+      var galleryImages = await findGalleryImages(galleryID);
+      var totalImageCount = galleryImages.length;
+      var currentImageIndex = galleryImages.indexOf(imageID);
+      var nextImageID =
+        galleryImages[wrapIndex(currentImageIndex + 1, totalImageCount)];
+      var prevImageID =
+        galleryImages[wrapIndex(currentImageIndex - 1, totalImageCount)];
+
+      // Add UI elements.
+      insertGalleryToolbar(currentImageIndex, totalImageCount, galleryImages);
+      insertArrowButtons(nextImageID, prevImageID);
+      insertArrowKeyHandlers(nextImageID, prevImageID);
+    }
+  }
+
+  function insertGalleryToolbar(
+    currentImageIndex,
+    totalImageCount,
+    galleryImages
+  ) {
+    var galleryToolbar = document.createElement("div");
+    galleryToolbar.innerHTML = `<span class="imageGalleryNav-NavTitle">Gallery Image: </span><input type="number" class="text-input imageGalleryNav-NavInput" value="${
+      currentImageIndex + 1
+    }"> <span class="imageGalleryNav-NavTotal">/ ${totalImageCount}</span>`;
+
+    var toolbar = document.querySelector("div.image-toolbar");
+    toolbar.parentNode.insertBefore(galleryToolbar, toolbar.nextSibling);
+
+    galleryToolbar.querySelector("input").addEventListener("change", (e) => {
+      var imageIndex = e.target.value - 1;
+      if (imageIndex < 0 || imageIndex > totalImageCount - 1) {
+        e.target.value = currentImageIndex + 1;
+        e.target.select();
+      } else {
+        var imageID = galleryImages[imageIndex];
+        redirectToImage(imageID);
+      }
+    });
+
+    galleryToolbar.querySelector("input").addEventListener("focus", (e) => {
+      e.target.select();
+    });
+  }
+
+  function insertArrowButtons(nextImageID, prevImageID) {
+    var leftButton = document.createElement("button");
+    leftButton.className = "imageGalleryNav-leftButton btn btn-primary";
+    leftButton.innerText = "<";
+    leftButton.addEventListener("click", () => {
+      redirectToImage(prevImageID);
+    });
+
+    var rightButton = document.createElement("button");
+    rightButton.className = "imageGalleryNav-rightButton btn btn-primary";
+    rightButton.innerText = ">";
+    rightButton.addEventListener("click", () => {
+      redirectToImage(nextImageID);
+    });
+
+    document.querySelector("div.image-container").prepend(leftButton);
+    document.querySelector("div.image-container").prepend(rightButton);
+  }
+
+  function insertArrowKeyHandlers(nextImageID, prevImageID) {
+    // TODO: Determine how to cleanup this listener properly, so that we can handle left/right arrow key.
+    // // Add keypress handlers for arrow keys.
+    // document.addEventListener('keydown', function onKeydownHandler(e) {
+    //   if (!isTextboxFocused()) {
+    //     if (e.key === "ArrowRight") {
+    //       redirectToImage(nextImageID);
+    //     } else if (e.key === "ArrowLeft") {
+    //       redirectToImage(prevImageID);
+    //     }
+    //   }
+    // });
+  }
+
+  // *** Utility Functions ***
+
+  function redirectToImage(imageID) {
+    const baseImagesPath = "/images/";
+    // window.location.href = `${baseImagesPath}${imageID}`;
+    window.location.replace(`${baseImagesPath}${imageID}`);
+  }
+
+  function isTextboxFocused() {
+    if (
+      document.activeElement.nodeName == "TEXTAREA" ||
+      document.activeElement.nodeName == "INPUT" ||
+      (document.activeElement.nodeName == "DIV" &&
+        document.activeElement.isContentEditable)
+    ) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  function wrapIndex(index, arrayLength) {
+    return ((index % arrayLength) + arrayLength) % arrayLength;
+  }
+
+  // *** GQL Calls ***
+
+  // Find Image by ID
+  // Return Galleries list (id)
+  async function findImage(imageID) {
+    const variables = { id: imageID };
+    const query = `query ($id: ID!) { findImage(id: $id) { galleries { id } } }`;
+    return await csLib
+      .callGQL({ query, variables })
+      .then((data) => data.findImage.galleries.map((item) => item.id));
+  }
+
+  // Find Images by Gallery ID
+  // Return Images list (id)
+  async function findGalleryImages(galleryID) {
+    const imageFilter = {
+      galleries: { value: galleryID, modifier: "INCLUDES_ALL" },
+    };
+    const findFilter = { per_page: -1, sort: "title" };
+    const variables = { image_filter: imageFilter, filter: findFilter };
+    const query = `query ($image_filter: ImageFilterType!, $filter: FindFilterType!) { findImages(image_filter: $image_filter, filter: $filter) { images { id } } }`;
+    return await csLib
+      .callGQL({ query, variables })
+      .then((data) => data.findImages.images.map((item) => item.id));
+  }
+
+  // Wait for video player to load on scene page.
+  csLib.PathElementListener(
+    "/galleries/",
+    ".image-card",
+    setupGalleryImageLinks
+  ); // PathElementListener is from cs-ui-lib.js
+
+  // Wait for video player to load on scene page.
+  csLib.PathElementListener(
+    "/images/",
+    ".image-container",
+    setupImageContainer
+  ); // PathElementListener is from cs-ui-lib.js
+})();

--- a/plugins/imageGalleryNavigation/imageGalleryNavigation.yml
+++ b/plugins/imageGalleryNavigation/imageGalleryNavigation.yml
@@ -1,0 +1,11 @@
+name: imageGalleryNavigation
+# requires: CommunityScriptsUILibrary
+description: This plugin adds features for navigating between images within a Gallery from the Image details page.
+version: 0.1
+ui:
+  requires:
+    - CommunityScriptsUILibrary
+  javascript:
+    - imageGalleryNavigation.js
+  css:
+    - imageGalleryNavigation.css


### PR DESCRIPTION
This plugin adds features for navigating between images within a Gallery from the Image details page. This is intended to make it easier to edit metadata on each Image in a Gallery one at a time without constantly having to go back and forth between the Gallery and Image page.

This plugin currently adds two things to the Image details page:
    - A line above the tabs in the left panel that indicates the current page and total number of pages in the current Gallery. The current image number can be changed to jump to a specific image within the Gallery.
    - Buttons along the left/right side of the main Image display panel that allow moving to the previous/next image in the Gallery.

In the case of Images that are in multiple Galleries, the Gallery being navigated is set by accessing an Images from the Gallery you want to navigate. Otherwise, if you navigate directly to an Image, the first Gallery the Image belongs to will be used as the basis for navigation.

Known issues/limitations:
    - Currently is hardcoded to always sort Images by title.

![image](https://github.com/user-attachments/assets/5a2fe2d5-047d-4f94-8ed0-9158da8b63c9)
