### PR TITLE
[tagCopyPaste] Add newline as list delimiter. Trim all input. Update README.

### DIFF
--- a/plugins/tagCopyPaste/README.md
+++ b/plugins/tagCopyPaste/README.md
@@ -2,11 +2,13 @@
 
 https://discourse.stashapp.cc/t/tagcopypaste/1858
 
-This plugin adds Copy and Paste buttons next to the Tags input field that allows for easier bulk adding and copying of tags, with the goal of making it easy to copy Tags between objects, bulk load manually created tag lists, or load tag lists copied from AI tagger output.
+This plugin adds Copy and Paste functionality to the Tags input field that allows for easier bulk adding and copying of tags, with the goal of making it easy to copy Tags between objects, bulk load manually created tag lists, or load tag lists copied from AI tagger output.
 
-The Copy button will create a comma delimited list of all currently entered tags and put this on your clipboard.
+Copy/Paste of Tags can be performed either with dedicated Copy/Paste buttons or by selecting the Tag input field and performing the typical CTRL+C/CTRL+V.
 
-The Paste button will check your current clipboard for a comma delimited string and add these as Tags, optionally creating any missing tags. Pasted tags will be checked against both primary Tag names and all aliases, comparisons are not case sensitive and allow "_" to be interpreted as a space.
+Copying will create a comma delimited list of all currently entered tags and put this on your clipboard.
+
+Pasting will check your current clipboard for a comma and/or newline delimited string and add these as Tags, optionally creating any missing tags. Pasted tags will be checked against both primary Tag names and all aliases, comparisons are not case sensitive and allow "_" to be interpreted as a space.
 
 **Note**: This plugin will prompt you to grant access to the clipboard. This must be granted in order for this plugin to work.
 

--- a/plugins/tagCopyPaste/tagCopyPaste.js
+++ b/plugins/tagCopyPaste/tagCopyPaste.js
@@ -7,8 +7,8 @@
 
   // helper function to get the innerText of all elements matching a selector
   const getAllInnerText = (selector) => Array.from(document.querySelectorAll(selector))
-    .map((el) => el.innerText)
-    .filter((text) => text.trim() !== "");
+    .map((el) => el.innerText.trim())
+    .filter((text) => text !== "");
 
   // On image page, get data about gallery (image's position within gallery, next/prev image IDs),
   // add arrow buttons to page, and register arrow keypress handlers,
@@ -80,10 +80,10 @@
   async function handlePasteClick(objID, objType) {
     // Parse tag list from comma delimited string.
     const tagInput = await navigator.clipboard.readText();
-    var inputTagList = tagInput.split(",") // do de-duplication later
+    var inputTagList = tagInput.split(/\r?\n|\r|,/).map(s => s.trim()).filter((text) => text !== "") // do de-duplication later
 
     // Get tags from input box and also add to tag list.
-    const existingTagList = getAllInnerText("label[for='tag_ids'] + div .react-select__multi-value__label")
+    const existingTagList = getAllInnerText("label[for='tag_ids'] + div .react-select__multi-value__label");
 
     inputTagList = [...new Set([...inputTagList, ...existingTagList])].sort();
 
@@ -93,7 +93,7 @@
 
     // Search for tag ID for each tag. If exists, add to tag ID list. If not exists, create new tag and add to tag ID list.
     for (const inputTag of inputTagList) {
-      const tagID = await getTagByName(inputTag.trim());
+      const tagID = await getTagByName(inputTag);
       if (tagID && tagID.length) {
         existingTags.push(inputTag);
         tagUpdateList.push(tagID[0]);
@@ -102,9 +102,7 @@
       }
     }
 
-
     if (pluginSettings.requireConfirmation) {
-
       const missingTagsStr = missingTags.join(", ");
       const existingTagsStr = existingTags.join(", ");
       const msg = pluginSettings.createIfNotExists
@@ -133,8 +131,6 @@
 
     window.location.reload();
   }
-
-  // *** Utility Functions ***
 
   // *** GQL Calls ***
 

--- a/plugins/tagCopyPaste/tagCopyPaste.yml
+++ b/plugins/tagCopyPaste/tagCopyPaste.yml
@@ -1,7 +1,7 @@
 name: tagCopyPaste
 # requires: CommunityScriptsUILibrary
 description: Adds Copy/Paste buttons to Tags field.
-version: 0.2
+version: 0.3
 settings:
   createIfNotExists:
     displayName: Create If Not Exists


### PR DESCRIPTION
A few small updates to tagCopyPaste.

- Adds newline as a valid delimiter for tag lists.
- Trim all input strings initially so trimming those values later is not necessary.
- Update README.