### PR TITLE
[Video Chapter Markers] Fix on update trigger

### DIFF
--- a/plugins/videoChapterMarkers/videoChapterMarkers.py
+++ b/plugins/videoChapterMarkers/videoChapterMarkers.py
@@ -110,9 +110,9 @@ if "mode" in json_input["args"]:
     PLUGIN_ARGS = json_input["args"]["mode"]
     if "processAll" == PLUGIN_ARGS:
         processAll()
-    elif "hookContext" in json_input["args"]:
-        _id = json_input["args"]["hookContext"]["id"]
-        _type = json_input["args"]["hookContext"]["type"]
-        if _type == "Scene.Update.Post":
-            scene = stash.find_scene(_id)
-            processScene(scene)
+if "hookContext" in json_input["args"]:
+    _id = json_input["args"]["hookContext"]["id"]
+    _type = json_input["args"]["hookContext"]["type"]
+    if _type == "Scene.Update.Post":
+        scene = stash.find_scene(_id)
+        processScene(scene)

--- a/plugins/videoChapterMarkers/videoChapterMarkers.yml
+++ b/plugins/videoChapterMarkers/videoChapterMarkers.yml
@@ -1,6 +1,6 @@
 name: Video Chapter Markers
 description: Create markers from chapter information embedded in video files
-version: 1.0
+version: 1.1
 url: https://github.com/stashapp/CommunityScripts/tree/main/plugins/videoChapterMarkers
 exec:
   - python


### PR DESCRIPTION
from what i can see, on stash 0.28.1 (latest stable release at time of writing) `Scene.Update.Post` gets called with only `args.hookContext` in json input. `args.mode` is only present for the `processAll` action when manually triggered in tasks section, and it is set like `args.mode == "processAll"`. the branch checking for `args.hookContext` was never reached as `args.mode` does not exist in these instances.