### PR TITLE
[audio-transcodes] Fix paths with spaces and ffmpeg stderr flood

### DIFF
--- a/plugins/audio-transcodes/audio-transcodes.py
+++ b/plugins/audio-transcodes/audio-transcodes.py
@@ -3,7 +3,7 @@ from stashapi.stashapp import StashInterface
 import sys
 import json
 from pathlib import Path
-import os
+import subprocess
 
 settings = {"hash_type": "oshash", "transcodes_dir": "/generated/transcodes/"}
 
@@ -18,12 +18,18 @@ def run_ffmpeg(file, hash):
                 dest,
             )
         )
-        command = (
-            "ffmpeg -f lavfi -i color=c=blue:s=1280x720 -i %s  -shortest -fflags +shortest %s"
-            % (file, dest)
-        )
+        command = [
+            "ffmpeg",
+            "-loglevel", "error",
+            "-f", "lavfi",
+            "-i", "color=c=blue:s=1280x720",
+            "-i", file,
+            "-shortest",
+            "-fflags", "+shortest",
+            dest,
+        ]
         log.debug("about to run command: %s " % (command,))
-        os.system(command)
+        subprocess.run(command)
     else:
         log.debug(
             "transcode already exists %s - %s"
@@ -59,7 +65,6 @@ FRAGMENT_SERVER = json_input["server_connection"]
 stash = StashInterface(FRAGMENT_SERVER)
 config = stash.get_configuration()
 
-log.debug(config)
 settings["transcodes_dir"] = config["general"]["generatedPath"]
 settings["hash_type"] = config["general"]["videoFileNamingAlgorithm"].lower()
 log.debug(settings)

--- a/plugins/audio-transcodes/audio-transcodes.yml
+++ b/plugins/audio-transcodes/audio-transcodes.yml
@@ -1,6 +1,6 @@
 name: audio-transcodes
 description: Generate a transcode video from an audio file
-version: 0.1
+version: 0.2
 url: https://github.com/stashapp/CommunityScripts/
 exec:
   - python


### PR DESCRIPTION
fixes audio transcodes with files that have spaces in them, forming a command using `%` (or any other string manipulation) is very dangerous at worst and wrong at best, this job should be handled by an appropriate library for running commands which can separate command arguments appropriately, aka subprocess.

also changes the ffmpeg command for audio transcodes to log fatal errors, otherwise the whole transcode log would show up as errors in stash even when it succeeded. also removes unnecessary logging of the whole stash configuration dict which can be several pages worth of scrolling while looking at logs.