### PR TITLE
[nfoSceneParser] new config options

### DIFF
--- a/plugins/nfoSceneParser/config.py
+++ b/plugins/nfoSceneParser/config.py
@@ -10,6 +10,11 @@ dry_mode = False
 # ! Not yet implemented. Currently, only "with files" is supported
 nfo_location = "with files"
 
+# By default the plugin will look for an nfo based on file name:
+# "Movie Title (2023).nfo"
+# If you want to use a custom file name eg. "movie.nfo", set it here.
+custom_nfo_name = ""
+
 # If True, will never update already "organized" scenes.
 skip_organized = True
 
@@ -40,6 +45,11 @@ create_missing_performers = True
 create_missing_studios = True
 create_missing_tags = True
 create_missing_movies = True
+
+# Choose which field should be parsed into user rating
+# and if it should be multiplied by a factor.
+user_rating_field = "userrating"
+user_rating_multiplier = 1
 
 ###############################################################################
 # Do not change config below unless you are absolutely sure of what you do...

--- a/plugins/nfoSceneParser/config.py
+++ b/plugins/nfoSceneParser/config.py
@@ -51,6 +51,10 @@ create_missing_movies = True
 user_rating_field = "userrating"
 user_rating_multiplier = 1
 
+# Let you decide from where genres should be loaded from.
+# Possible values: "tags", "genres", "both"
+load_tags_from = "both"
+
 ###############################################################################
 # Do not change config below unless you are absolutely sure of what you do...
 ###############################################################################

--- a/plugins/nfoSceneParser/nfoParser.py
+++ b/plugins/nfoSceneParser/nfoParser.py
@@ -127,17 +127,20 @@ class NfoParser(AbstractParser):
         return self._nfo_root.findtext("premiered") or year
 
     def __extract_nfo_tags(self):
+        source = config.load_tags_from.lower()
         file_tags = []
-        # from nfo <tag>
-        tags = self._nfo_root.findall("tag")
-        for tag in tags:
-            if tag.text:
-                file_tags.append(tag.text)
-        # from nfo <genre>
-        genres = self._nfo_root.findall("genre")
-        for genre in genres:
-            if genre.text:
-                file_tags.append(genre.text)
+        if source in ["tags", "both"]:
+            # from nfo <tag>
+            tags = self._nfo_root.findall("tag")
+            for tag in tags:
+                if tag.text:
+                    file_tags.append(tag.text)
+        if source in ["genres", "both"]:
+            # from nfo <genre>
+            genres = self._nfo_root.findall("genre")
+            for genre in genres:
+                if genre.text:
+                    file_tags.append(genre.text)
         return list(set(file_tags))
 
     def __extract_nfo_actors(self):

--- a/plugins/nfoSceneParser/nfoParser.py
+++ b/plugins/nfoSceneParser/nfoParser.py
@@ -154,6 +154,8 @@ class NfoParser(AbstractParser):
 
     def parse(self):
         if not self._nfo_file or not os.path.exists(self._nfo_file):
+            if self._nfo_file:
+                log.LogDebug(f"The NFO file \"{os.path.split(self._nfo_file)[1]}\" was not found")
             return {}
         log.LogDebug("Parsing '{}'".format(self._nfo_file))
         # Parse NFO xml content

--- a/plugins/nfoSceneParser/nfoParser.py
+++ b/plugins/nfoSceneParser/nfoParser.py
@@ -16,13 +16,16 @@ class NfoParser(AbstractParser):
             self._defaults = defaults
         # Finds nfo file
         self._nfo_file = None
+        dir_path = os.path.dirname(scene_path)
         if config.nfo_location.lower() == "with files":
             if folder_mode:
                 # look in current dir & parents for a folder.nfo file...
-                dir_path = os.path.dirname(scene_path)
                 self._nfo_file = self._find_in_parents(dir_path, "folder.nfo")
             else:
-                self._nfo_file = os.path.splitext(scene_path)[0] + ".nfo"
+                if len(config.custom_nfo_name) > 0:
+                    self._nfo_file = os.path.join(dir_path, config.custom_nfo_name)
+                else:
+                    self._nfo_file = os.path.splitext(scene_path)[0] + ".nfo"
         # else:
             # TODO: support dedicated dir instead of "with files" (compatibility with nfo exporters)
         self._nfo_root = None
@@ -56,7 +59,7 @@ class NfoParser(AbstractParser):
         # Not found? Look tor folder image...
         path_dir = os.path.dirname(self._nfo_file)
         folder_files = sorted(glob.glob(f"{glob.escape(path_dir)}{os.path.sep}*.*"))
-        folder_pattern = re.compile("^.*(landscape\\d{0,2}|thumb\\d{0,2}|poster\\d{0,2}|cover\\d{0,2})\\.(jpe?g|png|webp)$", re.I)
+        folder_pattern = re.compile("^.*(landscape\\d{0,2}|thumb\\d{0,2}|poster\\d{0,2}|folder\\d{0,2}|cover\\d{0,2})\\.(jpe?g|png|webp)$", re.I)
         result = self.__match_image_files(folder_files, folder_pattern)
         return result
 
@@ -103,7 +106,7 @@ class NfoParser(AbstractParser):
         return file_images
 
     def __extract_nfo_rating(self):
-        user_rating = round(float(self._nfo_root.findtext("userrating") or 0))
+        user_rating = round(float(self._nfo_root.findtext(config.user_rating_field) or 0) * config.user_rating_multiplier)
         if user_rating > 0:
             return user_rating
         # <rating> is converted to a scale of 5 if needed

--- a/plugins/nfoSceneParser/nfoParser.py
+++ b/plugins/nfoSceneParser/nfoParser.py
@@ -22,7 +22,7 @@ class NfoParser(AbstractParser):
                 # look in current dir & parents for a folder.nfo file...
                 self._nfo_file = self._find_in_parents(dir_path, "folder.nfo")
             else:
-                if len(config.custom_nfo_name) > 0:
+                if len(getattr(config, "custom_nfo_name", "")) > 0:
                     self._nfo_file = os.path.join(dir_path, config.custom_nfo_name)
                 else:
                     self._nfo_file = os.path.splitext(scene_path)[0] + ".nfo"
@@ -106,7 +106,8 @@ class NfoParser(AbstractParser):
         return file_images
 
     def __extract_nfo_rating(self):
-        user_rating = round(float(self._nfo_root.findtext(config.user_rating_field) or 0) * config.user_rating_multiplier)
+        multiplier = getattr(config, "user_rating_multiplier", 1)
+        user_rating = round(float(self._nfo_root.findtext(getattr(config, "user_rating_field", "userrating")) or 0) * multiplier)
         if user_rating > 0:
             return user_rating
         # <rating> is converted to a scale of 5 if needed
@@ -127,7 +128,7 @@ class NfoParser(AbstractParser):
         return self._nfo_root.findtext("premiered") or year
 
     def __extract_nfo_tags(self):
-        source = config.load_tags_from.lower()
+        source = getattr(config, "load_tags_from", "both").lower()
         file_tags = []
         if source in ["tags", "both"]:
             # from nfo <tag>

--- a/plugins/nfoSceneParser/nfoSceneParser.yml
+++ b/plugins/nfoSceneParser/nfoSceneParser.yml
@@ -1,7 +1,7 @@
 name: nfoSceneParser
 description: Fills scene data from NFO or filename pattern
 url: https://github.com/stashapp/CommunityScripts/tree/main/plugins/nfoSceneParser
-version: 1.3.1
+version: 1.4.0
 exec:
   - python
   - "{pluginDir}/nfoSceneParser.py"
@@ -16,4 +16,4 @@ tasks:
     description: Reload all scenes that have specific "marker" tag (see plugin's config.py)
     defaultArgs:
       mode: reload
-# Last Updated January 3, 2024
+# Last Updated June 24, 2025

--- a/plugins/nfoSceneParser/stashInterface.py
+++ b/plugins/nfoSceneParser/stashInterface.py
@@ -149,6 +149,7 @@ class StashInterface:
             "date": scene_data["date"],
             "rating100": scene_data["rating"],
             "urls": scene_data["urls"],
+            "studio_id": scene_data["studio_id"],
             "code": scene_data["code"],
             "performer_ids": scene_data["performer_ids"],
             "tag_ids": scene_data["tag_ids"],


### PR DESCRIPTION
Added possibility for nfoSceneParser plugin to configure:
- custom name of the nfo file
- name of the user rating field
- user rating multiplier
- source for tags

Additionally added:
- missing studio information on scene update
- "folder" as possible name for scene image