### PR TITLE
[PerformerStashboxUrlToID] Support TPDB performer URLs

### DIFF
--- a/plugins/performerStashboxUrlToID/performerStashboxUrlToID.py
+++ b/plugins/performerStashboxUrlToID/performerStashboxUrlToID.py
@@ -2,12 +2,14 @@ import stashapi.log as log
 from stashapi.stashapp import StashInterface
 import sys
 import json
+import uuid
 
 STASH_BOXES = [
     "https://fansdb.cc",
     "https://pmvstash.org",
     "https://stashdb.org",
-    "https://javstash.org"
+    "https://javstash.org",
+    "https://theporndb.net",
 ]
 
 def processPerformer(performer):
@@ -18,9 +20,15 @@ def processPerformer(performer):
     for url in performer["urls"]:
         log.trace(url)
         for domain in STASH_BOXES:
-            if domain in url and f"{domain}/graphql" not in stash_boxes:
+            if f"{domain}/performers/" in url and f"{domain}/graphql" not in stash_boxes:
+                try:
+                    stash_box_id = url.rstrip("/").rsplit("/", 1)[1]
+                    stash_box_id = str(uuid.UUID(stash_box_id, version=4))
+                except ValueError:
+                    continue
+
                 performer_update["stash_ids"].append(
-                    {"endpoint": f"{domain}/graphql", "stash_id": url[-36:]}
+                    {"endpoint": f"{domain}/graphql", "stash_id": stash_box_id}
                 )
                 needs_update = True
                 log.info("Adding stashbox %s to performer %s" % (domain, performer["id"]))

--- a/plugins/performerStashboxUrlToID/performerStashboxUrlToID.yml
+++ b/plugins/performerStashboxUrlToID/performerStashboxUrlToID.yml
@@ -1,6 +1,6 @@
 name: Performer Stashbox Url to ID
 description: If the performer has a url for another stashbox add it as an id to the performer
-version: 0.2
+version: 0.3
 url: https://github.com/stashapp/CommunityScripts/
 exec:
   - python
@@ -8,7 +8,7 @@ exec:
 interface: raw
 hooks:
   - name: Process Performer
-    description: Adds extra tags to scenes
+    description: Adds/updates stashbox IDs based on the performer URLs
     triggeredBy:
       - Performer.Update.Post
       - Performer.Create.Post


### PR DESCRIPTION
This adds the TPDB domain to the list of valid stash boxes that can be detected by the "PerformerStashboxUrlToID" plugin. Because TPDB has multiple possible perfromer links, we need to add a check specific for links with the `/performers/` prefix that Stash-Box expects. This also adds a UUID check to make sure the Stash-Box ID is in the correct format, since TPDB is also a bit more relaxed about that.