### PR TITLE
Fix issue #609

### DIFF
--- a/plugins/defaultDataForPath/defaultDataForPath.js
+++ b/plugins/defaultDataForPath/defaultDataForPath.js
@@ -226,7 +226,7 @@ query findGallery($id: ID!) {\
     return null;
   }
 
-  var path = findGallery.folder.path
+  var path = findGallery.folder.path;
   return path;
 }
 


### PR DESCRIPTION
See https://github.com/stashapp/CommunityScripts/issues/609 for full context.

Basically `path` field doesn't exist on `Gallery` and `findGallery` takes ` ID!` not `ID`.

the `path` value from `Folder` is _probably_ the best substitute, as it'll return something sane regardless if the gallery is a folder, zip, or comic-book-archive