### PR TITLE
TPDBMarkers: Fix syntax error

### DIFF
--- a/plugins/TPDBMarkers/tpdbMarkers.py
+++ b/plugins/TPDBMarkers/tpdbMarkers.py
@@ -47,7 +47,7 @@ def processScene(scene):
                             marker["tags"].append(int(getTag("[TPDBMarker]")))
 
                         if settings["addTPDBMarkerTitle"]:
-                            marker["title"] = f"[TPDBMarker] {m["title"]}"
+                            marker["title"] = f'[TPDBMarker] {m["title"]}'
 
                         markers.append(marker)
 


### PR DESCRIPTION
Noticed this syntax error (introduced in #602) when running locally via the following error log:

```
DEBU[2025-09-12 19:00:48] Plugin The Porn DB Markers started: /Users/alex/.pyenv/shims/python3 plugins/community/TPDBMarkers/tpdbMarkers.py
ERRO[2025-09-12 19:00:48] [Plugin / The Porn DB Markers]   File "/Users/alex/Code/stash-app/plugins/community/TPDBMarkers/tpdbMarkers.py", line 50
ERRO[2025-09-12 19:00:48] [Plugin / The Porn DB Markers]     marker["title"] = f"[TPDBMarker] {m["title"]}"
ERRO[2025-09-12 19:00:48] [Plugin / The Porn DB Markers]                                          ^^^^^
ERRO[2025-09-12 19:00:48] [Plugin / The Porn DB Markers] SyntaxError: f-string: unmatched '['
DEBU[2025-09-12 19:00:48] Plugin The Porn DB Markers finished
```

The inner double quotes should either be escaped, or the outer double quotes replaced with single quotes (as this PR does).