### PR TITLE
Update tagScenesWithPerfTags.py

### DIFF
--- a/plugins/tagScenesWithPerfTags/tagScenesWithPerfTags.py
+++ b/plugins/tagScenesWithPerfTags/tagScenesWithPerfTags.py
@@ -121,5 +121,5 @@ elif "hookContext" in json_input["args"]:
         ) and "inputFields" in json_input["args"]["hookContext"]
         and len(json_input["args"]["hookContext"]["inputFields"]) > 2
     ):
-        scene = stash.find_scene(id)
+        scene = stash.find_scene(id, fragment="id organized tags {name} performers {id}")
         processScene(scene)

--- a/plugins/tagScenesWithPerfTags/tagScenesWithPerfTags.yml
+++ b/plugins/tagScenesWithPerfTags/tagScenesWithPerfTags.yml
@@ -1,6 +1,6 @@
 name: Tag Scenes From Performer Tags
 description: tags scenes with performer tags.
-version: 0.2.2
+version: 0.2.3
 exec:
   - python
   - "{pluginDir}/tagScenesWithPerfTags.py"


### PR DESCRIPTION
fix fragment requirement for find_scene
this should resolve this issue https://github.com/stashapp/CommunityScripts/issues/594

a number of other plugins are experiencing the same issue which this example can be used to fix others. Example:
https://github.com/stashapp/CommunityScripts/issues/599
