### PR TITLE
[imageGalleryNavigation] Add basic zoom/pan to Image detail page.

### DIFF
--- a/plugins/imageGalleryNavigation/README.md
+++ b/plugins/imageGalleryNavigation/README.md
@@ -4,9 +4,10 @@ https://discourse.stashapp.cc/t/imagegallerynavigation/1857
 
 This plugin adds features for navigating between images within a Gallery from the Image details page. This is intended to make it easier to edit metadata on each Image in a Gallery one at a time without constantly having to go back and forth between the Gallery and Image page.
 
-This plugin currently adds two things to the Image details page:
+This plugin currently adds the following to the Image details page:
     - A line above the tabs in the left panel that indicates the current page and total number of pages in the current Gallery. The current image number can be changed to jump to a specific image within the Gallery.
     - Buttons along the left/right side of the main Image display panel that allow moving to the previous/next image in the Gallery.
+    - Basic zoom (mouse wheel) and pan (click and drag) functionality (can be enabled/disabled in plugin settings). Zooming out to original scale will also reset the image position.
 
 In the case of Images that are in multiple Galleries, the Gallery being navigated is set by accessing an Image from the Gallery you want to navigate. When navigating to an Image from a Gallery, the sorting/filtering currently on the Gallery view will also be applied to the Gallery navigation on the Image page.
 

--- a/plugins/imageGalleryNavigation/imageGalleryNavigation.yml
+++ b/plugins/imageGalleryNavigation/imageGalleryNavigation.yml
@@ -1,7 +1,12 @@
 name: imageGalleryNavigation
 # requires: CommunityScriptsUILibrary
 description: This plugin adds features for navigating between images within a Gallery from the Image details page.
-version: 0.2
+version: 0.3
+settings:
+  enableTransform:
+    displayName: Enable Zoom/Pan
+    description: Enable zoom (mouse wheel) and pan (click and drag) on Image detail page.
+    type: BOOLEAN
 ui:
   requires:
     - CommunityScriptsUILibrary


### PR DESCRIPTION
This adds basic mouse wheel zoom and click-and-drag panning (similar to lightbox popup) to the Image detail page. This can be enabled/disabled in plugin settings.