### PR TITLE
[tagCopyPaste] Fix issue where copy/paste handler could be attached multiple times.

### DIFF
--- a/plugins/tagCopyPaste/tagCopyPaste.yml
+++ b/plugins/tagCopyPaste/tagCopyPaste.yml
@@ -1,7 +1,7 @@
 name: tagCopyPaste
 # requires: CommunityScriptsUILibrary
 description: Adds Copy/Paste buttons to Tags field.
-version: 0.3
+version: 0.4
 settings:
   createIfNotExists:
     displayName: Create If Not Exists


### PR DESCRIPTION
Refactors copy/paste event handlers to no longer be anonymous functions, so that we can detach in order to prevent them from being attached multiple times.

I'm not sure if it's some quirk of the UI itself or the plugin UI library, but the `PathElementListener` function was consistently triggering twice which was leading to this issue (only noticeable when copy/pasting into the control, not when clicking the copy/paste buttons).