### PR TITLE
SFWSwitch: blur tagger scene image popup

### DIFF
--- a/plugins/SFWSwitch/sfw.css
+++ b/plugins/SFWSwitch/sfw.css
@@ -9,6 +9,7 @@
 video,
 .scene-cover,
 .scrubber-item,
+.scene-image,
 
 /* image */
 .image-card-preview,
@@ -85,6 +86,7 @@ div:hover > .scene-header,
 .image-thumbnail:hover,
 .scene-card-preview:hover,
 .scrubber-item:hover,
+.scene-image:hover,
 
 /* image */
 .image-image:hover,


### PR DESCRIPTION
In Tagger mode when you get a result for a scene (for example by clicking Scrape by fragment), the image is not blurred. 

By adding the missing CSS for .scene-image it now works as expected.