### PR TITLE
Add Info JSON Importer plugin

### DIFF
--- a/plugins/infoJsonImporter/README.md
+++ b/plugins/infoJsonImporter/README.md
@@ -1,0 +1,156 @@
+# Info JSON Importer
+
+**Imports metadata from yt-dlp `.info.json` files directly into Stash.**
+
+Developed by [David Smith](mailto:david@maxprovider.net) · © David Smith 2026
+
+---
+
+## What It Does
+
+When you download videos with [yt-dlp](https://github.com/yt-dlp/yt-dlp), it can optionally save a companion `.info.json` file alongside each video containing metadata from the source site — title, upload date, tags, uploader name, description and more.
+
+This plugin scans every scene in your Stash library, looks for a matching `.info.json` file next to the video, and imports the following fields into Stash:
+
+| Field | Imported As |
+|---|---|
+| `title` | Scene title |
+| `upload_date` | Scene date |
+| `uploader` / `channel` | Studio (created if not exists) |
+| `tags` | Scene tags (created if not exists) |
+| `description` | Scene details |
+
+Studios and tags that do not already exist in Stash are created automatically during the import.
+
+---
+
+## Requirements
+
+- Stash v0.25.0 or later
+- Python 3 (accessible as `python3`)
+- pip
+- yt-dlp `.info.json` files saved alongside your video files
+
+Your video filenames must follow the standard yt-dlp naming format with the video ID in square brackets, and the `.info.json` must share the same base name:
+
+```
+Some_Video_Title [ph63841ed468601].mp4
+Some_Video_Title [ph63841ed468601].info.json  ← this is what the plugin reads
+```
+
+If you have existing videos without `.info.json` files, use [MetaFetch](https://github.com/stashapp/CommunityScripts) or run yt-dlp with `--write-info-json --skip-download` to generate them retroactively.
+
+---
+
+## Installation
+
+### Using setup.sh (recommended)
+
+1. Download all four plugin files into a folder on your computer
+2. Run the setup script from that folder:
+
+```bash
+chmod +x setup.sh
+./setup.sh
+```
+
+The script will:
+- Ask for your Stash API key
+- Ask for your Stash plugins folder location (defaults to `~/.stash/plugins/`)
+- Write the API key into the plugin
+- Copy the plugin files to the correct location
+- Install the required `requests` Python library
+
+3. Open Stash in your browser
+4. Go to **Settings → Plugins** and click **Reload Plugins**
+5. Go to **Settings → Tasks** — you will see **Info JSON Importer** listed
+
+### Manual installation
+
+1. Copy the `infoJsonImporter/` folder into your Stash plugins directory (typically `~/.stash/plugins/`)
+2. Edit `infoJsonImporter.py` and set your API key:
+   ```python
+   API_KEY = "your-api-key-here"
+   ```
+3. Install the required dependency:
+   ```bash
+   pip install requests --break-system-packages
+   ```
+4. In Stash go to **Settings → Plugins → Reload Plugins**
+
+---
+
+## Getting Your Stash API Key
+
+In Stash go to: **Settings → Security → API Key → Generate**
+
+Copy the key that appears and paste it when `setup.sh` asks, or set it manually in `infoJsonImporter.py`.
+
+> If your Stash instance has no authentication enabled (no username/password required), leave the API key blank.
+
+---
+
+## Usage
+
+Two tasks are available under **Settings → Tasks → Info JSON Importer**:
+
+### Dry Run (preview only)
+Scans all scenes and shows what would be imported — titles, dates, studios and tag counts — **without making any changes to Stash**. Always run this first to verify the plugin is working correctly.
+
+### Import Info JSON
+Performs the actual import. Updates all scenes that have a matching `.info.json` file. Creates any missing studios and tags automatically.
+
+> On a large library this may take 30–60 minutes. Plugin output appears in **Settings → Logs**. Set the log level to **Debug** to see per-scene detail.
+
+---
+
+## Summary Output
+
+When complete, a summary is shown in the logs:
+
+```
+============================================================
+Info JSON Importer complete
+  Scenes scanned:       19306
+  Info JSON found:      18119
+  No JSON found:         1011
+  No video file:          176
+  Successfully updated: 18119
+  Errors:                   0
+============================================================
+```
+
+---
+
+## Re-running
+
+The plugin can be re-run safely at any time. It overwrites existing metadata with whatever is in the `.info.json` file, so running it again after adding new `.info.json` files will pick up the new ones.
+
+---
+
+## Troubleshooting
+
+**Plugin does not appear in Stash**
+Make sure both `infoJsonImporter.yml` and `infoJsonImporter.py` are in the same folder inside your plugins directory, then click **Reload Plugins**.
+
+**401 Unauthorized in logs**
+Your API key is missing or incorrect. Re-run `setup.sh` or edit the `API_KEY` line in `infoJsonImporter.py` directly.
+
+**Runs instantly with no output**
+Check **Settings → Logs** with Debug level. If you see a connection error, verify Stash is running and the API key is correct.
+
+**High number of scenes with no JSON found**
+Your `.info.json` files may have different names than the video files. The plugin looks for a `.info.json` with exactly the same base name as the video file.
+
+**Plugin finishes but metadata not visible**
+Run a Metadata Scan in Stash (**Settings → Tasks → Scan**) after the import to refresh the display.
+
+---
+
+## Notes
+
+- The plugin never modifies, moves or deletes your video files
+- Only scenes already in your Stash library are processed
+- Scenes without a matching `.info.json` file are skipped silently
+- Tags and studios are created with the exact names from the JSON file
+- Description is imported as the Stash **Details** field on each scene

--- a/plugins/infoJsonImporter/README.txt
+++ b/plugins/infoJsonImporter/README.txt
@@ -1,0 +1,146 @@
+Info JSON Importer — Stash Plugin
+==================================
+© David Smith 2026 · david@maxprovider.net
+Version: 1.0.0  |  Created: 26 April 2026
+
+Imports metadata from yt-dlp .info.json files directly into Stash.
+For every scene in your Stash library, if a matching .info.json file
+exists alongside the video, the following fields are imported:
+
+  - Title
+  - Date (upload date from the source site)
+  - Studio (from the uploader/channel name)
+  - Tags (all tags from the source site)
+  - Description
+
+Studios and tags that do not already exist in Stash are created
+automatically during the import.
+
+FILES
+-----
+infoJsonImporter.yml   Plugin configuration (Stash reads this)
+infoJsonImporter.py    Plugin logic
+setup.sh               Interactive setup script
+README.txt             This file
+
+REQUIREMENTS
+------------
+- Stash v0.25.0 or later
+- Python 3 installed and accessible as 'python3'
+- pip (to install the 'requests' library)
+- yt-dlp .info.json files saved alongside your video files
+
+Your video filenames must follow the yt-dlp naming format with the
+video ID in square brackets, and the .info.json file must have the
+same base name as the video:
+
+  Some_Video_Title [ph63841ed468601].mp4
+  Some_Video_Title [ph63841ed468601].info.json  ← this is what we read
+
+INSTALLATION
+------------
+1. Download all plugin files into a folder on your computer
+
+2. Run the setup script from that folder:
+
+     chmod +x setup.sh
+     ./setup.sh
+
+   The setup script will:
+   - Ask for your Stash API key
+   - Ask for your Stash plugins folder location
+   - Write the API key into the plugin
+   - Copy the plugin files to the correct location
+   - Install the required 'requests' Python library
+
+3. Open Stash in your browser
+
+4. Go to Settings → Plugins and click Reload Plugins
+
+5. Go to Settings → Tasks — you will see Info JSON Importer listed
+
+GETTING YOUR STASH API KEY
+--------------------------
+In Stash go to:
+  Settings → Security → API Key → Generate
+
+Copy the key that appears. You will paste it when setup.sh asks for it.
+
+If you do not have authentication enabled on your Stash (no username/
+password required to access it), you can leave the API key blank when
+setup.sh asks — the plugin will connect without one.
+
+YOUR STASH PLUGINS FOLDER
+--------------------------
+The default location is:
+
+  ~/.stash/plugins/
+
+If you have configured Stash to use a different data directory, your
+plugins folder will be inside that directory instead. You can find it
+in Stash under Settings → System → Paths.
+
+The setup script asks you for this path and defaults to ~/.stash/plugins/
+if you just press Enter.
+
+RUNNING THE PLUGIN
+------------------
+Two tasks are available under Settings → Tasks → Info JSON Importer:
+
+  Dry Run (preview only)
+    Scans all scenes and shows what would be imported — titles, dates,
+    studios and tag counts — without making any changes to Stash.
+    Always run this first to verify the plugin is working correctly.
+
+  Import Info JSON
+    Performs the actual import. Updates all scenes that have a matching
+    .info.json file. Creates any missing studios and tags automatically.
+    On a large library this may take 30-60 minutes.
+
+Plugin output appears in Stash under Settings → Logs. Set the log
+level to Debug to see per-scene detail.
+
+A summary is shown at the end:
+
+  Scenes scanned:       Total scenes in your Stash library
+  Info JSON found:      Scenes with a matching .info.json file
+  No JSON found:        Scenes with no .info.json (will be skipped)
+  No video file:        Scenes whose video file could not be found
+  Successfully updated: Scenes updated in Stash (live run only)
+
+RE-RUNNING
+----------
+The plugin can be re-run safely at any time. It overwrites existing
+metadata with whatever is in the .info.json file, so running it again
+after adding new .info.json files will pick up the new ones.
+
+TROUBLESHOOTING
+---------------
+Plugin does not appear in Stash
+  Make sure both infoJsonImporter.yml and infoJsonImporter.py are in
+  the same folder inside your plugins directory, and click Reload Plugins.
+
+401 Unauthorized in logs
+  Your API key is missing or incorrect. Re-run setup.sh and enter the
+  correct key, then reload the plugin.
+
+0 scenes updated / runs instantly with no output
+  Check Settings → Logs with Debug level. If you see a connection error,
+  verify Stash is running and the API key is correct.
+
+High number of scenes with no JSON found
+  Your .info.json files may be in a different location or have different
+  names than the video files. The plugin looks for a .info.json file
+  with exactly the same base name as the video file.
+
+Plugin finishes but metadata not appearing in Stash
+  Run a Metadata Scan in Stash (Settings → Tasks → Scan) after the
+  import to ensure Stash refreshes its display.
+
+NOTES
+-----
+- The plugin never modifies, moves or deletes your video files
+- Only scenes already in your Stash library are processed
+- Scenes without a matching .info.json file are skipped silently
+- Tags and studios are created with the exact names from the JSON file
+- Description is imported as the Stash 'Details' field on each scene

--- a/plugins/infoJsonImporter/infoJsonImporter.py
+++ b/plugins/infoJsonImporter/infoJsonImporter.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""
+================================================================================
+ Info JSON Importer — Stash Plugin
+================================================================================
+ Reads yt-dlp .info.json files saved alongside video files and imports their
+ metadata into Stash via the GraphQL API.
+
+ Fields imported from .info.json:
+   title       -> Scene title
+   description -> Scene details
+   upload_date -> Scene date (YYYYMMDD -> YYYY-MM-DD)
+   uploader    -> Studio name (created if not exists)
+   tags        -> Scene tags (created if not exists)
+
+ Two tasks available:
+   Import Info JSON  — actually updates Stash scenes
+   Dry Run           — previews what would change, makes no modifications
+
+ Version:  1.0.0
+ Created:  26 April 2026
+ Author:   David Smith
+ Contact:  david@maxprovider.net
+ © David Smith 2026
+================================================================================
+"""
+
+import sys
+import os
+import json
+import re
+import argparse
+import requests
+from pathlib import Path
+
+# ── Read connection parameters from Stash (passed via stdin) ──────────────────
+# Stash passes a JSON blob to stdin containing server connection details
+# and any plugin arguments.
+try:
+    raw = sys.stdin.read()
+    plugin_input = json.loads(raw)
+except Exception:
+    plugin_input = {}
+
+server = plugin_input.get("server_connection", {})
+SCHEME  = server.get("Scheme", "http")
+HOST    = server.get("Host", "localhost")
+PORT    = server.get("Port", 9999)
+
+# Normalise 0.0.0.0 to localhost
+if HOST == "0.0.0.0":
+    HOST = "localhost"
+
+GRAPHQL_URL = f"{SCHEME}://{HOST}:{PORT}/graphql"
+
+# ── API key ────────────────────────────────────────────────────────────────────
+# Set your Stash API key here, or use the provided setup.sh script to set it
+# automatically. Generate a key in Stash: Settings → Security → API Key
+# Leave empty ("") if your Stash instance has no authentication enabled.
+API_KEY = ""
+
+HEADERS = {
+    "Content-Type": "application/json",
+    "ApiKey": API_KEY,
+}
+
+# ── Parse task argument ───────────────────────────────────────────────────────
+parser = argparse.ArgumentParser()
+parser.add_argument("--task", default="import", choices=["import", "dryrun"])
+args, _ = parser.parse_known_args()
+DRY_RUN = (args.task == "dryrun")
+
+def log(msg, level="info"):
+    """
+    Send a log message to Stash in the required format.
+    Stash reads plugin output line by line looking for this prefix.
+    """
+    prefix = {
+        "trace":   "TRACE",
+        "debug":   "DEBUG",
+        "info":    "INFO",
+        "warning": "WARN",
+        "error":   "ERROR",
+        "progress":"PROGRESS",
+    }.get(level, "INFO")
+    print(f"{prefix} {msg}", file=sys.stderr, flush=True)
+
+def gql(query, variables=None):
+    """Execute a GraphQL query/mutation against the Stash API."""
+    payload = {"query": query}
+    if variables:
+        payload["variables"] = variables
+    try:
+        r = requests.post(GRAPHQL_URL, json=payload, headers=HEADERS, timeout=30)
+        r.raise_for_status()
+        data = r.json()
+        if "errors" in data:
+            log(f"  GraphQL error: {data['errors']}")
+            return None
+        return data.get("data")
+    except Exception as e:
+        log(f"  Request failed: {e}")
+        return None
+
+# ── GraphQL queries and mutations ─────────────────────────────────────────────
+
+def get_all_scenes():
+    """Fetch all scenes from Stash with their file paths."""
+    query = """
+    query AllScenes($page: Int!) {
+        findScenes(
+            filter: { per_page: 100, page: $page }
+            scene_filter: {}
+        ) {
+            count
+            scenes {
+                id
+                title
+                files {
+                    path
+                }
+            }
+        }
+    }
+    """
+    all_scenes = []
+    page = 1
+    while True:
+        data = gql(query, {"page": page})
+        if not data:
+            break
+        result = data.get("findScenes", {})
+        scenes = result.get("scenes", [])
+        all_scenes.extend(scenes)
+        if len(all_scenes) >= result.get("count", 0):
+            break
+        page += 1
+    return all_scenes
+
+def find_or_create_studio(name):
+    """Find a studio by name, or create it if it doesn't exist."""
+    query = """
+    query FindStudio($name: String!) {
+        findStudios(
+            studio_filter: { name: { value: $name, modifier: EQUALS } }
+            filter: { per_page: 1 }
+        ) {
+            studios { id name }
+        }
+    }
+    """
+    data = gql(query, {"name": name})
+    if data:
+        studios = data.get("findStudios", {}).get("studios", [])
+        if studios:
+            return studios[0]["id"]
+
+    # Create the studio
+    mutation = """
+    mutation CreateStudio($name: String!) {
+        studioCreate(input: { name: $name }) { id }
+    }
+    """
+    data = gql(mutation, {"name": name})
+    if data:
+        return data.get("studioCreate", {}).get("id")
+    return None
+
+def find_or_create_tag(name):
+    """Find a tag by name, or create it if it doesn't exist."""
+    query = """
+    query FindTag($name: String!) {
+        findTags(
+            tag_filter: { name: { value: $name, modifier: EQUALS } }
+            filter: { per_page: 1 }
+        ) {
+            tags { id name }
+        }
+    }
+    """
+    data = gql(query, {"name": name})
+    if data:
+        tags = data.get("findTags", {}).get("tags", [])
+        if tags:
+            return tags[0]["id"]
+
+    # Create the tag
+    mutation = """
+    mutation CreateTag($name: String!) {
+        tagCreate(input: { name: $name }) { id }
+    }
+    """
+    data = gql(mutation, {"name": name})
+    if data:
+        return data.get("tagCreate", {}).get("id")
+    return None
+
+def update_scene(scene_id, title=None, details=None, date=None,
+                 studio_id=None, tag_ids=None):
+    """Update a scene's metadata in Stash."""
+    input_data = {"id": scene_id}
+    if title:     input_data["title"]     = title
+    if details:   input_data["details"]   = details
+    if date:      input_data["date"]      = date
+    if studio_id: input_data["studio_id"] = studio_id
+    if tag_ids:   input_data["tag_ids"]   = tag_ids
+
+    mutation = """
+    mutation UpdateScene($input: SceneUpdateInput!) {
+        sceneUpdate(input: $input) { id title }
+    }
+    """
+    return gql(mutation, {"input": input_data})
+
+# ── Info JSON parsing ─────────────────────────────────────────────────────────
+
+def find_info_json(video_path):
+    """
+    Look for a .info.json file next to the video file.
+    Tries exact base name match first, then any [ID].info.json in same folder.
+    """
+    p = Path(video_path)
+    # Standard yt-dlp naming: same name, different extension
+    candidate = p.with_suffix(".info.json")
+    if candidate.exists():
+        return candidate
+
+    # Also try stripping the extension and checking for .info.json
+    stem = p.stem  # e.g. "Title [phABC123]"
+    candidate2 = p.parent / f"{stem}.info.json"
+    if candidate2.exists():
+        return candidate2
+
+    return None
+
+def parse_info_json(json_path):
+    """
+    Parse a yt-dlp .info.json file and extract relevant metadata fields.
+    Returns a dict with keys: title, description, date, uploader, tags.
+    """
+    try:
+        with open(json_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception as e:
+        log(f"  Failed to parse {json_path}: {e}")
+        return None
+
+    result = {}
+
+    # Title
+    title = data.get("title") or data.get("fulltitle")
+    if title:
+        result["title"] = title.strip()
+
+    # Description
+    desc = data.get("description")
+    if desc:
+        result["description"] = desc.strip()
+
+    # Upload date — yt-dlp stores as YYYYMMDD string
+    upload_date = data.get("upload_date")
+    if upload_date and re.match(r"^\d{8}$", upload_date):
+        result["date"] = f"{upload_date[:4]}-{upload_date[4:6]}-{upload_date[6:]}"
+
+    # Uploader — use as studio name
+    uploader = data.get("uploader") or data.get("channel")
+    if uploader:
+        result["uploader"] = uploader.strip()
+
+    # Tags — yt-dlp stores as list of strings
+    tags = data.get("tags")
+    if tags and isinstance(tags, list):
+        # Filter out empty strings and deduplicate
+        result["tags"] = list({t.strip() for t in tags if t and t.strip()})
+
+    return result
+
+# ── Main import logic ─────────────────────────────────────────────────────────
+
+def run_import():
+    mode = "DRY RUN — no changes will be made" if DRY_RUN else "LIVE — Stash will be updated"
+    log(f"Info JSON Importer starting — {mode}")
+    log(f"Connecting to Stash at {GRAPHQL_URL}")
+    log("")
+
+    # Verify connection
+    test = gql("query { version { version } }")
+    if not test:
+        log("ERROR: Could not connect to Stash. Check your API key and Stash is running.")
+        sys.exit(1)
+    stash_version = test.get("version", {}).get("version", "unknown")
+    log(f"Connected to Stash {stash_version}")
+    log("")
+
+    # Fetch all scenes
+    log("Fetching all scenes from Stash...")
+    scenes = get_all_scenes()
+    log(f"Found {len(scenes)} scenes total")
+    log("")
+
+    # Counters
+    found      = 0
+    updated    = 0
+    no_json    = 0
+    no_file    = 0
+    errors     = 0
+
+    for i, scene in enumerate(scenes, 1):
+        # Get the primary file path
+        files = scene.get("files", [])
+        if not files:
+            no_file += 1
+            continue
+
+        video_path = files[0].get("path", "")
+        if not video_path or not os.path.exists(video_path):
+            no_file += 1
+            continue
+
+        # Look for .info.json
+        json_path = find_info_json(video_path)
+        if not json_path:
+            no_json += 1
+            continue
+
+        found += 1
+        meta = parse_info_json(json_path)
+        if not meta:
+            errors += 1
+            continue
+
+        scene_id    = scene["id"]
+        scene_title = scene.get("title") or os.path.basename(video_path)
+        short_name  = scene_title[:60] + "..." if len(scene_title) > 60 else scene_title
+
+        log(f"[{i}/{len(scenes)}] {short_name}")
+        log(f"  JSON: {json_path.name}")
+
+        if DRY_RUN:
+            # Just show what would happen
+            if "title"       in meta: log(f"  Would set title:       {meta['title'][:70]}")
+            if "date"        in meta: log(f"  Would set date:        {meta['date']}")
+            if "uploader"    in meta: log(f"  Would set studio:      {meta['uploader']}")
+            if "description" in meta: log(f"  Would set description: {meta['description'][:60]}...")
+            if "tags"        in meta: log(f"  Would set {len(meta['tags'])} tags")
+            updated += 1
+            continue
+
+        # Resolve studio ID
+        studio_id = None
+        if "uploader" in meta:
+            studio_id = find_or_create_studio(meta["uploader"])
+            if studio_id:
+                log(f"  Studio: {meta['uploader']}")
+
+        # Resolve tag IDs
+        tag_ids = []
+        if "tags" in meta:
+            for tag_name in meta["tags"][:50]:  # cap at 50 tags
+                tid = find_or_create_tag(tag_name)
+                if tid:
+                    tag_ids.append(tid)
+            if tag_ids:
+                log(f"  Tags: {len(tag_ids)} applied")
+
+        # Update the scene
+        result = update_scene(
+            scene_id   = scene_id,
+            title      = meta.get("title"),
+            details    = meta.get("description"),
+            date       = meta.get("date"),
+            studio_id  = studio_id,
+            tag_ids    = tag_ids if tag_ids else None,
+        )
+
+        if result:
+            updated += 1
+            log(f"  Updated OK")
+        else:
+            errors += 1
+            log(f"  Update FAILED")
+
+    # Summary
+    log("")
+    log("=" * 60)
+    log(f"Info JSON Importer complete")
+    log(f"  Scenes scanned:      {len(scenes)}")
+    log(f"  Info JSON found:     {found}")
+    log(f"  No video file:       {no_file}")
+    log(f"  No JSON found:       {no_json}")
+    if DRY_RUN:
+        log(f"  Would update:        {updated}")
+    else:
+        log(f"  Successfully updated:{updated}")
+        log(f"  Errors:              {errors}")
+    log("=" * 60)
+
+if __name__ == "__main__":
+    run_import()

--- a/plugins/infoJsonImporter/infoJsonImporter.yml
+++ b/plugins/infoJsonImporter/infoJsonImporter.yml
@@ -1,0 +1,21 @@
+name: "Info JSON Importer"
+description: "Imports metadata from yt-dlp .info.json files into Stash scenes. Reads title, date, description, tags and studio from .info.json files saved alongside your videos. Developed by David Smith © 2026."
+version: "1.0.0"
+url: ""
+
+exec:
+  - "python3"
+  - "{pluginDir}/infoJsonImporter.py"
+
+interface: raw
+
+tasks:
+  - name: "Import Info JSON"
+    description: "Scan all scenes for .info.json files and import their metadata into Stash."
+    execArgs:
+      - "--task=import"
+
+  - name: "Dry Run (preview only)"
+    description: "Preview what would be imported without making any changes to Stash."
+    execArgs:
+      - "--task=dryrun"

--- a/plugins/infoJsonImporter/setup.sh
+++ b/plugins/infoJsonImporter/setup.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# =============================================================================
+# Info JSON Importer — Setup Script
+# =============================================================================
+# © David Smith 2026 · david@maxprovider.net
+#
+# This script sets your Stash API key in the plugin, then copies the plugin
+# files into your Stash plugins directory.
+#
+# Run this from the folder containing the plugin files:
+#   chmod +x setup.sh
+#   ./setup.sh
+# =============================================================================
+
+set -e
+
+SCRIPT_DIR="$(dirname "$(readlink -f "${0}")")"
+PLUGIN_FILE="$SCRIPT_DIR/infoJsonImporter.py"
+
+echo ""
+echo "╔══════════════════════════════════════════════════════╗"
+echo "║         Info JSON Importer — Setup                   ║"
+echo "╠══════════════════════════════════════════════════════╣"
+echo "║  © David Smith 2026 · david@maxprovider.net          ║"
+echo "╚══════════════════════════════════════════════════════╝"
+echo ""
+
+# ── Check plugin files are present ────────────────────────────────────────────
+for f in infoJsonImporter.py infoJsonImporter.yml; do
+    if [ ! -f "$SCRIPT_DIR/$f" ]; then
+        echo "❌ Required file not found: $f"
+        echo "   Make sure all plugin files are in the same folder as setup.sh"
+        exit 1
+    fi
+done
+echo "✅ Plugin files found"
+
+# ── Ask for Stash API key ─────────────────────────────────────────────────────
+echo ""
+echo "Your Stash API key is needed so the plugin can connect to Stash."
+echo "To generate one: Stash → Settings → Security → API Key → Generate"
+echo ""
+read -p "Enter your Stash API key: " API_KEY
+
+if [ -z "$API_KEY" ]; then
+    echo "❌ No API key entered. Exiting."
+    exit 1
+fi
+
+# ── Write API key into the plugin script ──────────────────────────────────────
+python3 - << PYEOF
+import re
+
+with open('$PLUGIN_FILE', 'r') as f:
+    content = f.read()
+
+# Replace the API_KEY line with the provided key
+new_content = re.sub(
+    r'^API_KEY = ".*"',
+    'API_KEY = "$API_KEY"',
+    content,
+    flags=re.MULTILINE
+)
+
+with open('$PLUGIN_FILE', 'w') as f:
+    f.write(new_content)
+
+print("✅ API key written to plugin")
+PYEOF
+
+# ── Ask for Stash plugins directory ──────────────────────────────────────────
+echo ""
+echo "Where is your Stash plugins folder?"
+echo "Default is: $HOME/.stash/plugins"
+echo "(Press Enter to use the default, or type the full path)"
+echo ""
+read -p "Stash plugins folder: " PLUGINS_DIR
+
+if [ -z "$PLUGINS_DIR" ]; then
+    PLUGINS_DIR="$HOME/.stash/plugins"
+fi
+
+# Expand ~ if user typed it literally
+PLUGINS_DIR="${PLUGINS_DIR/#\~/$HOME}"
+
+if [ ! -d "$PLUGINS_DIR" ]; then
+    echo ""
+    echo "Directory not found: $PLUGINS_DIR"
+    read -p "Create it? (y/n): " CREATE_DIR
+    if [ "$CREATE_DIR" = "y" ] || [ "$CREATE_DIR" = "Y" ]; then
+        mkdir -p "$PLUGINS_DIR"
+        echo "✅ Created $PLUGINS_DIR"
+    else
+        echo "❌ Cannot continue without a valid plugins directory."
+        exit 1
+    fi
+fi
+
+# ── Copy plugin files ─────────────────────────────────────────────────────────
+DEST="$PLUGINS_DIR/infoJsonImporter"
+mkdir -p "$DEST"
+cp "$SCRIPT_DIR/infoJsonImporter.py"  "$DEST/"
+cp "$SCRIPT_DIR/infoJsonImporter.yml" "$DEST/"
+echo "✅ Plugin files copied to $DEST"
+
+# ── Install Python dependency ─────────────────────────────────────────────────
+echo ""
+echo "Installing required Python library (requests)..."
+pip install requests --break-system-packages -q
+echo "✅ Dependencies installed"
+
+# ── Done ──────────────────────────────────────────────────────────────────────
+echo ""
+echo "══════════════════════════════════════════════════════"
+echo "  ✅ Setup complete!"
+echo ""
+echo "  Next steps:"
+echo "  1. Open Stash in your browser"
+echo "  2. Go to Settings → Plugins"
+echo "  3. Click Reload Plugins"
+echo "  4. Go to Settings → Tasks"
+echo "  5. Find Info JSON Importer"
+echo "  6. Run Dry Run first to preview"
+echo "  7. Run Import Info JSON to apply"
+echo "══════════════════════════════════════════════════════"
+echo ""


### PR DESCRIPTION
## Info JSON Importer

Adds a new plugin that imports metadata from yt-dlp .info.json files directly into Stash scenes.

### What it does

Many users have large video libraries downloaded with yt-dlp that have .info.json files saved alongside the videos. Until now there was no way to get that metadata into Stash without scraping the source sites again. This plugin reads the local .info.json files and imports directly from them.

For each scene in the Stash library, the plugin looks for a matching .info.json file next to the video file and imports:
- Title
- Date (upload_date)
- Studio (from uploader/channel, created if not exists)
- Tags (created if not exists)
- Description (into the Details field)

### Tasks

Two tasks are provided:
- **Dry Run** — previews what would be imported without making any changes
- **Import Info JSON** — performs the actual import

### Notes

- Written in Python using the Stash GraphQL API
- Includes a setup.sh script that asks for the API key and copies files automatically
- Tested on Stash v0.31.1 on Linux
- Works with Pornhub and XHamster .info.json files (and any other yt-dlp generated .info.json)

Developed by David Smith © 2026
david@maxprovider.net