### PR TITLE
feat(SFWSwitch): add Never Unblur on Hover setting

### DIFF
--- a/plugins/SFWSwitch/README.md
+++ b/plugins/SFWSwitch/README.md
@@ -9,8 +9,10 @@ https://discourse.stashapp.cc/t/sfw-switch/4658
   - Gray = Blur disabled
 - Toggling the button blurs cover images and other content.
 - Hovering over an image temporarily removes the blur.
+- Optional toggle to also mute audio from scenes.
+- Optional toggle to not remove the blur on thumbnail hover.
 - Extends the blurring functionality to some community plugins. 
-  - Custom selectors should should be added to `additional_plugins.css` file.
+  - Custom selectors should be added to `additional_plugins.css` file.
 
 ## Screenshots
 

--- a/plugins/SFWSwitch/sfw.js
+++ b/plugins/SFWSwitch/sfw.js
@@ -17,10 +17,10 @@ async function getSfwConfig() {
         });
         const result = await response.json();
         const pluginSettings = result.data.configuration.plugins.sfwswitch;
-        return pluginSettings?.audio_setting === true;
+        return { audioMute: pluginSettings?.audio_setting === true, neverUnblur: pluginSettings?.never_unblur === true };
     } catch (e) {
         console.error("SFW Switch: Could not fetch config", e);
-        return false;
+        return { audioMute: false, neverUnblur: false };
     }
 }
 
@@ -30,9 +30,10 @@ async function sfw_mode() {
     if (!stash_css) return;
     const rawState = localStorage.getItem("sfw_mode");
     const sfwState = rawState === "true";
-    const audioMuteEnabled = await getSfwConfig();
+    const { audioMute: audioMuteEnabled, neverUnblur } = await getSfwConfig();
 
     stash_css.disabled = !sfwState;
+    sfw_apply_never_unblur(sfwState && neverUnblur);
 
     if (sfwState && audioMuteEnabled) {
         sfw_mute_all_media();
@@ -141,7 +142,8 @@ async function sfwswitch_switcher() {
 
     localStorage.setItem("sfw_mode", enabled);
 
-    const audioMuteEnabled = await getSfwConfig();
+    const { audioMute: audioMuteEnabled, neverUnblur } = await getSfwConfig();
+    sfw_apply_never_unblur(enabled && neverUnblur);
 
     if (enabled && audioMuteEnabled) {
         sfw_mute_all_media();
@@ -158,6 +160,37 @@ async function sfwswitch_switcher() {
     const button = document.getElementById("plugin_sfw");
     if (button) {
         button.style.color = enabled ? "#5cff00" : "#f5f8fa";
+    }
+}
+
+const SFW_NEVER_UNBLUR_CSS = [
+    ".thumbnail-container img,.detail-header-image,.wall-item-gallery,",
+    ".scene-player-container,.scene-cover,.scene-card-preview,.scrubber-item,",
+    ".scene-image,.scene-card img,.wall-item-media,.wall-item.show-title,",
+    ".image-card img,.image-thumbnail,.Lightbox-carousel,.image-image,",
+    ".react-photo-gallery--gallery img,.group-card-image,.gallery-image,",
+    ".gallery-card-image,.gallery-card img,.gallery-cover img,",
+    ".GalleryWallCard.GalleryWallCard-portrait,.GalleryWallCard.GalleryWallCard-landscape,",
+    ".performer-card img,.studio-card-image,.studio-card img,.tag-card img",
+    "{filter:blur(30px)!important}",
+    ".card-section-title,.detail-item-value,.TruncatedText,.scene-studio-overlay,",
+    ".scene-header>h3,h3.scene-header,.queue-scene-details,.marker-wall,",
+    ".performer-name,.card-section,.name-data,.aliases-data,.gallery-header.no-studio,",
+    ".studio-name,.studio-overlay a,.studio-logo,.studio-parent-studios,",
+    ".group-details>div>h2,h3.image-header,.TruncatedText.image-card__description,",
+    ".TruncatedText.tag-description,.tag-item.tag-link.badge.badge-secondary,.tag-name",
+    "{filter:blur(2px)!important}",
+].join("");
+
+function sfw_apply_never_unblur(enabled) {
+    const existing = document.getElementById("sfw-never-unblur");
+    if (enabled && !existing) {
+        const style = document.createElement("style");
+        style.id = "sfw-never-unblur";
+        style.textContent = SFW_NEVER_UNBLUR_CSS;
+        document.head.appendChild(style);
+    } else if (!enabled && existing) {
+        existing.remove();
     }
 }
 

--- a/plugins/SFWSwitch/sfw.js
+++ b/plugins/SFWSwitch/sfw.js
@@ -1,6 +1,6 @@
 let sfw_mediaObserver = null;
 let sfw_playListener = null;
-let sfw_extraListeners = null; 
+let sfw_extraListeners = null;
 
 async function getSfwConfig() {
     try {
@@ -163,32 +163,28 @@ async function sfwswitch_switcher() {
     }
 }
 
-const SFW_NEVER_UNBLUR_CSS = [
-    ".thumbnail-container img,.detail-header-image,.wall-item-gallery,",
-    ".scene-player-container,.scene-cover,.scene-card-preview,.scrubber-item,",
-    ".scene-image,.scene-card img,.wall-item-media,.wall-item.show-title,",
-    ".image-card img,.image-thumbnail,.Lightbox-carousel,.image-image,",
-    ".react-photo-gallery--gallery img,.group-card-image,.gallery-image,",
-    ".gallery-card-image,.gallery-card img,.gallery-cover img,",
-    ".GalleryWallCard.GalleryWallCard-portrait,.GalleryWallCard.GalleryWallCard-landscape,",
-    ".performer-card img,.studio-card-image,.studio-card img,.tag-card img",
-    "{filter:blur(30px)!important}",
-    ".card-section-title,.detail-item-value,.TruncatedText,.scene-studio-overlay,",
-    ".scene-header>h3,h3.scene-header,.queue-scene-details,.marker-wall,",
-    ".performer-name,.card-section,.name-data,.aliases-data,.gallery-header.no-studio,",
-    ".studio-name,.studio-overlay a,.studio-logo,.studio-parent-studios,",
-    ".group-details>div>h2,h3.image-header,.TruncatedText.image-card__description,",
-    ".TruncatedText.tag-description,.tag-item.tag-link.badge.badge-secondary,.tag-name",
-    "{filter:blur(2px)!important}",
-].join("");
-
 function sfw_apply_never_unblur(enabled) {
     const existing = document.getElementById("sfw-never-unblur");
     if (enabled && !existing) {
-        const style = document.createElement("style");
-        style.id = "sfw-never-unblur";
-        style.textContent = SFW_NEVER_UNBLUR_CSS;
-        document.head.appendChild(style);
+        let css = "";
+        for (let s = 0; s < document.styleSheets.length; s++) {
+            const sheet = document.styleSheets[s];
+            try {
+                if (!sheet.href || !sheet.href.includes("/plugin/sfwswitch/css")) continue;
+                for (let i = 0; i < sheet.cssRules.length; i++) {
+                    const rule = sheet.cssRules[i];
+                    if (rule instanceof CSSStyleRule && !rule.selectorText.includes(":hover")) {
+                        css += `${rule.selectorText}{filter:${rule.style.filter}!important}`;
+                    }
+                }
+            } catch (e) {}
+        }
+        if (css) {
+            const style = document.createElement("style");
+            style.id = "sfw-never-unblur";
+            style.textContent = css;
+            document.head.appendChild(style);
+        }
     } else if (!enabled && existing) {
         existing.remove();
     }

--- a/plugins/SFWSwitch/sfwswitch.yml
+++ b/plugins/SFWSwitch/sfwswitch.yml
@@ -1,6 +1,6 @@
 name: SFW Switch
-description: Add a button to blur covers and images.
-version: 1.8
+description: Add a button to the menu bar to blur images, text and optionally mute audio.
+version: 1.9
 url: https://discourse.stashapp.cc/t/sfw-switch/4658
 ui:
   javascript:

--- a/plugins/SFWSwitch/sfwswitch.yml
+++ b/plugins/SFWSwitch/sfwswitch.yml
@@ -13,3 +13,7 @@ settings:
     displayName: Enable Sound Mute
     description: By default the plugin does not mute sound. Enabling this feature will have sound sources included when the SFW button is enabled.
     type: BOOLEAN
+  never_unblur:
+    displayName: Never Unblur on Hover
+    description: Keep images blurred even when hovered.
+    type: BOOLEAN


### PR DESCRIPTION
Adds a new boolean plugin setting **Never Unblur on Hover** (`never_unblur`) to the SFW Switch plugin.

When enabled, all blurred content stays blurred even when hovered.

## Changes
- `sfwswitch.yml`: new `never_unblur` boolean setting
- `sfw.js`: read the new setting and inject/remove a `<style>` element that overrides the hover unblur rules when active