### PR TITLE
[SceneThumbnails] Add Scene Thumbnails plugin

### DIFF
--- a/plugins/SceneThumbnails/LICENSE
+++ b/plugins/SceneThumbnails/LICENSE
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/plugins/SceneThumbnails/README.md
+++ b/plugins/SceneThumbnails/README.md
@@ -1,0 +1,23 @@
+# Scene Thumbnails
+
+Scene Thumbnails adds a dismissable thumbnail grid to Stash scene pages. Each tile shows a frame of the video; clicking a tile seeks playback to that point, and a live highlight follows the current playing position. The grid lives in a drawer at the bottom of the scene panel.
+
+Built entirely in the browser from Stash's existing scene sprite and WebVTT — no generation, no ffmpeg, nothing written to disk. The only thing saved is your grid-size preference, kept in the browser (localStorage).
+
+## Features
+
+- Thumbnail grid in a dismissable drawer at the bottom of the scene panel (open with the "Scene Thumbnails" toggle below the video)
+- Click a tile to seek to that point in the video; clicking a tile dismisses the drawer
+- Live highlight that tracks playback position
+
+## Requirements
+
+- Stash with scene sprites generated (Generate → Sprites)
+
+## Credits
+
+Inspired by and partially derived from Mosaic Poster (https://discourse.stashapp.cc/t/mosaic-poster/12358), part of stashapp/CommunityScripts. Mosaic Poster replaces the pre-playback poster; Scene Thumbnails adds a thumbnail grid shown in a dismissable drawer at the bottom of the scene panel, with a live highlight.
+
+## License
+
+Licensed under the GNU Affero General Public License v3.0. See LICENSE.

--- a/plugins/SceneThumbnails/SceneThumbnails.js
+++ b/plugins/SceneThumbnails/SceneThumbnails.js
@@ -1,0 +1,723 @@
+/* Scene Thumbnails - a thumbnail grid for Stash scene pages.
+ *
+ * Portions (the scene-sprite/WebVTT data pipeline) are
+ * derived from Mosaic Poster
+ * (https://discourse.stashapp.cc/t/mosaic-poster/12358), part of
+ * stashapp/CommunityScripts (https://github.com/stashapp/CommunityScripts),
+ * licensed under the GNU Affero General Public License v3.0. Modified
+ * 2026-08-06: the poster overlay was replaced with a scrubber shown in a
+ * drawer that hovers above the bottom of the scene page, styled like the
+ * Stash collapsible sidebar sections, with a live playback highlight and a
+ * thumbnail-size toggle and a full-height toggle. The drawer is opened via the
+ * "Scene Thumbnails" button below the native scrubber and dismissed by clicking a
+ * tile, the backdrop, the header, or Escape. The thumbnail grid fills the width
+  * of the drawer; the slider selects how many thumbnails sit per row (1, 2, 3, 4,
+  * 6, or 12 — divisors of 12 so each row fills completely; left-to-right the
+  * slider goes small-to-large, i.e. 12 → 1 per row) using the gallery's
+ * zoom-slider component, with a constant 2px gutter between tiles.
+ *
+ * This file is licensed under the GNU Affero General Public License v3.0.
+ * See LICENSE for the full text.
+ */
+(() => {
+  "use strict";
+
+  const IDRE = /^\/scenes\/(\d+)(?:\/|$)/;
+  const CHEV_UP =
+    "M201.4 105.4c12.5-12.5 32.8-12.5 45.3 0l192 192c12.5 12.5 12.5 32.8 0 45.3s-32.8 12.5-45.3 0L224 173.3 54.6 342.6c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3l192-192z";
+  const CHEV_DOWN =
+    "M201.4 406.6c12.5 12.5 32.8 12.5 45.3 0l192-192c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L224 338.7 54.6 169.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3l192 192z";
+  const ICON_FILM =
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="18" rx="2"/><line x1="7" y1="3" x2="7" y2="21"/><line x1="17" y1="3" x2="17" y2="21"/></svg>';
+  const ICON_EXPAND =
+    "M32 32C14.3 32 0 46.3 0 64l0 96c0 17.7 14.3 32 32 32s32-14.3 32-32l0-64 64 0c17.7 0 32-14.3 32-32s-14.3-32-32-32L32 32zM64 352c0-17.7-14.3-32-32-32S0 334.3 0 352l0 96c0 17.7 14.3 32 32 32l96 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-64 0 0-64zM320 32c-17.7 0-32 14.3-32 32s14.3 32 32 32l64 0 0 64c0 17.7 14.3 32 32 32s32-14.3 32-32l0-96c0-17.7-14.3-32-32-32l-96 0zM448 352c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 64-64 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l96 0c17.7 0 32-14.3 32-32l0-96z";
+  const ICON_COMPRESS =
+    "M160 64c0-17.7-14.3-32-32-32S96 46.3 96 64l0 64-64 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l96 0c17.7 0 32-14.3 32-32l0-96zM32 320c-17.7 0-32 14.3-32 32s14.3 32 32 32l64 0 0 64c0 17.7 14.3 32 32 32s32-14.3 32-32l0-96c0-17.7-14.3-32-32-32l-96 0zM352 64c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 96c0 17.7 14.3 32 32 32l96 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-64 0 0-64zM320 320c-17.7 0-32 14.3-32 32l0 96c0 17.7 14.3 32 32 32s32-14.3 32-32l0-64 64 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-96 0z";
+  const COL_OPTIONS = [1, 2, 3, 4, 6, 12];
+  const TILE_GAP = 2;
+  const COL_OPTION_COUNT = COL_OPTIONS.length;
+
+  function svgChevron(d, name) {
+    return (
+      '<svg xmlns="http://www.w3.org/2000/svg" class="svg-inline--fa fa-fw" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="' +
+      name +
+      '" role="img" viewBox="0 0 448 512"><path fill="currentColor" d="' +
+      d +
+      '"/></svg>'
+    );
+  }
+
+  function svgIcon(d, name, viewBox) {
+    return (
+      '<svg xmlns="http://www.w3.org/2000/svg" class="svg-inline--fa fa-fw" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="' +
+      name +
+      '" role="img" viewBox="' +
+      viewBox +
+      '"><path fill="currentColor" d="' +
+      d +
+      '"/></svg>'
+    );
+  }
+
+  let currentVideo = null;
+  let syncTimer = null;
+  let scrubberFor = null;
+  let toggleEl = null;
+  let drawerEl = null;
+  let drawerTiles = null;
+  let drawerContent = null;
+  let sizesEl = null;
+  let backdropEl = null;
+  let drawerOpen = false;
+  let drawerMaximized = false;
+  let scrubberData = null;
+  let tileSets = [];
+  let lastVideoTime = 0;
+  let dataCache = null;
+  let colIndex = 4;
+
+  try {
+    const stored = localStorage.getItem("sceneThumbnails.colsPerRow");
+    const val = parseInt(stored, 10);
+    if (stored != null && !isNaN(val)) {
+      const idx = COL_OPTIONS.indexOf(val);
+      if (idx !== -1) colIndex = idx;
+    }
+  } catch (e) { }
+
+  function tilesPerRow() {
+    return COL_OPTIONS[colIndex];
+  }
+
+  function tileWidthForRow() {
+    const el = drawerTiles || document.querySelector(".full-scrubber-tiles");
+    const cw = el ? el.clientWidth : 0;
+    if (!cw || !scrubberData) return 80;
+    const n = tilesPerRow();
+    return Math.max(1, (cw - TILE_GAP * (n - 1)) / n);
+  }
+
+  function graphql(query, variables) {
+    return fetch("/graphql", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "same-origin",
+      body: JSON.stringify({ query, variables }),
+    }).then((r) => r.json());
+  }
+
+  function loadImage(src) {
+    return new Promise((resolve, reject) => {
+      const img = new Image();
+      img.onload = () => resolve(img);
+      img.onerror = reject;
+      img.src = src;
+    });
+  }
+
+  function vttSeconds(s) {
+    const parts = String(s).trim().split(":");
+    let sec = 0;
+    for (const p of parts) sec = sec * 60 + parseFloat(p || 0);
+    return Number.isNaN(sec) ? 0 : sec;
+  }
+
+  function fmt(t) {
+    t = Math.max(0, Math.floor(t));
+    const s = t % 60;
+    const m = Math.floor(t / 60) % 60;
+    const h = Math.floor(t / 3600);
+    return (h ? h + ":" : "") + String(m).padStart(2, "0") + ":" + String(s).padStart(2, "0");
+  }
+
+  function fetchCues(vttUrl) {
+    return fetch(vttUrl, { credentials: "same-origin" })
+      .then((r) => (r.ok ? r.text() : ""))
+      .then((text) => {
+        const cues = [];
+        const lines = text.split(/\r?\n/);
+        for (let i = 0; i < lines.length; i++) {
+          const arrow = lines[i].indexOf("-->");
+          if (arrow < 0) continue;
+          const start = vttSeconds(lines[i].slice(0, arrow));
+          for (
+            let j = i + 1;
+            j < lines.length && lines[j].indexOf("-->") < 0;
+            j++
+          ) {
+            const m = lines[j].match(/#xywh=(\d+),(\d+),(\d+),(\d+)/);
+            if (m) {
+              cues.push({ t: start, x: +m[1], y: +m[2], w: +m[3], h: +m[4] });
+              break;
+            }
+          }
+        }
+        return cues.length ? cues : null;
+      });
+  }
+
+  function loadSceneData(id) {
+    return graphql("query($id: ID!){ findScene(id: $id) { paths { sprite vtt } } }", {
+      id,
+    })
+      .then((j) => {
+        const scene = j.data && j.data.findScene;
+        const paths = scene && scene.paths;
+        return paths && paths.sprite ? paths : null;
+      })
+      .then((paths) => {
+        if (!paths) return null;
+        const vttUrl =
+          paths.vtt || paths.sprite.replace(/_sprite\.jpg(\?.*)?$/, "_thumbs.vtt");
+        return Promise.all([fetchCues(vttUrl), loadImage(paths.sprite)]).then(
+          ([cues, img]) =>
+            cues
+              ? {
+                cues,
+                img,
+                spriteUrl: paths.sprite,
+                spriteW: img.naturalWidth,
+                spriteH: img.naturalHeight,
+              }
+              : null
+        );
+      })
+      .catch(() => null);
+  }
+
+  function getData(id) {
+    if (dataCache && dataCache.id === id) return Promise.resolve(dataCache.data);
+    return loadSceneData(id).then((data) => {
+      dataCache = { id, data };
+      return data;
+    });
+  }
+
+  function seekTo(t) {
+    const playerEl = document.querySelector(".video-js");
+    const video =
+      (playerEl &&
+        (playerEl.querySelector("video") || playerEl.querySelector(".vjs-tech"))) ||
+      document.querySelector(".vjs-tech") ||
+      document.querySelector("video");
+    if (!video) return;
+    const doSeek = () => {
+      try {
+        video.currentTime = t;
+      } catch (e) { }
+      video.play().catch(() => { });
+    };
+    if (video.readyState >= 1) {
+      doSeek();
+    } else {
+      video.addEventListener("loadedmetadata", doSeek, { once: true });
+      video.play().catch(() => { });
+    }
+  }
+
+  function highlightSet(set, t) {
+    if (!scrubberData || !set.tiles.length) return;
+    const cues = scrubberData.cues;
+    let idx = 0;
+    for (let i = 0; i < cues.length; i++) {
+      if (cues[i].t <= t) idx = i;
+      else break;
+    }
+    if (idx === set.highlighted) return;
+    if (set.highlighted != null && set.tiles[set.highlighted]) {
+      const prev = set.tiles[set.highlighted];
+      prev.style.outline = "";
+      prev.style.zIndex = "";
+    }
+    if (set.tiles[idx]) {
+      const cur = set.tiles[idx];
+      cur.style.outline = "4px solid #4a9eff";
+      cur.style.zIndex = "2";
+    }
+    set.highlighted = idx;
+  }
+
+  function updateHighlight(t) {
+    if (!scrubberData) return;
+    for (const set of tileSets) highlightSet(set, t);
+  }
+
+  function syncTime() {
+    try {
+      lastVideoTime = (currentVideo && currentVideo.currentTime) || 0;
+    } catch (err) {
+      lastVideoTime = 0;
+    }
+    updateHighlight(lastVideoTime);
+  }
+
+  function onTime() {
+    syncTime();
+  }
+
+  function attachListeners(video) {
+    if (video === currentVideo) {
+      syncTime();
+      return;
+    }
+    if (currentVideo) {
+      currentVideo.removeEventListener("timeupdate", onTime);
+      currentVideo.removeEventListener("seeked", onTime);
+      currentVideo.removeEventListener("loadedmetadata", onTime);
+      currentVideo.removeEventListener("durationchange", onTime);
+      currentVideo.removeEventListener("play", onTime);
+    }
+    currentVideo = video || null;
+    if (syncTimer) clearInterval(syncTimer);
+    syncTimer = null;
+    if (currentVideo) {
+      currentVideo.addEventListener("timeupdate", onTime);
+      currentVideo.addEventListener("seeked", onTime);
+      currentVideo.addEventListener("loadedmetadata", onTime);
+      currentVideo.addEventListener("durationchange", onTime);
+      currentVideo.addEventListener("play", onTime);
+      syncTimer = setInterval(syncTime, 500);
+    }
+    syncTime();
+  }
+
+  function buildTiles(cont, data) {
+    const set = { tiles: [], highlighted: null };
+    tileSets.push(set);
+    scrubberData = data;
+
+    const cues = data.cues;
+    const n = tilesPerRow();
+    const sizeW = tileWidthForRow();
+    const scale = sizeW / cues[0].w;
+    const tileH = Math.max(1, Math.round(cues[0].h * scale));
+    const bgSize =
+      Math.round(data.spriteW * scale) + "px " + Math.round(data.spriteH * scale) + "px";
+    const tileWidthPct = "calc((100% - " + TILE_GAP + "px * " + (n - 1) + ") / " + n + ")";
+
+    for (let i = 0; i < cues.length; i++) {
+      const c = cues[i];
+      const nextStart = i + 1 < cues.length ? cues[i + 1].t : c.t + (c.t - (cues[i - 1]?.t || 0)) || 0;
+      const startStr = fmt(c.t);
+      const endStr = fmt(nextStart);
+      const tile = document.createElement("div");
+      tile.className = "scene-mosaic-tile";
+      tile.title = startStr + " - " + endStr;
+      tile.style.cssText =
+        "width:" +
+        tileWidthPct +
+        ";height:" +
+        tileH +
+        "px;max-width:" +
+        tileWidthPct +
+        ";flex:0 0 0%;flex-basis:" +
+        tileWidthPct +
+        ";cursor:pointer;position:relative;" +
+        "background-image:url('" +
+        data.spriteUrl +
+        "');" +
+        "background-size:" +
+        bgSize +
+        ";" +
+        "background-position:" +
+        -Math.round(c.x * scale) +
+        "px " +
+        -Math.round(c.y * scale) +
+        "px;";
+      const timeEl = document.createElement("div");
+      timeEl.className = "scrubber-item-time";
+      timeEl.textContent = startStr + " - " + endStr;
+      timeEl.style.cssText =
+        "color:white;font-size:10px;position:absolute;bottom:0;left:0;right:0;" +
+        "text-align:center;text-shadow:1px 1px black;pointer-events:none;";
+      tile.appendChild(timeEl);
+      tile.addEventListener("click", (function (t) {
+        return function () {
+          seekTo(t);
+          closeDrawer();
+          window.scrollTo({ top: 0, behavior: "smooth" });
+        };
+      })(c.t));
+      cont.appendChild(tile);
+      set.tiles.push(tile);
+    }
+    updateHighlight(lastVideoTime);
+  }
+
+  function insertAfter(node, ref) {
+    if (!ref || !ref.parentNode) return;
+    ref.parentNode.insertBefore(node, ref.nextSibling);
+  }
+
+  function ensureStyles() {
+    if (document.getElementById("full-scrubber-styles")) return;
+    const s = document.createElement("style");
+    s.id = "full-scrubber-styles";
+    s.textContent =
+      ".full-scrubber-toggle{display:flex;align-items:center;justify-content:center;gap:.5rem;width:100%;padding:.55rem;background:transparent;border:1px solid #3b4853;border-radius:.25rem;color:#c8cdd4;cursor:pointer;font-size:.8rem;}" +
+      ".full-scrubber-toggle:hover{border-color:#4a9eff;color:#fff;}" +
+      ".full-scrubber-backdrop{position:fixed;inset:0;z-index:1040;background:rgba(0,0,0,.2);opacity:0;pointer-events:none;transition:opacity .2s ease;}" +
+      ".full-scrubber-backdrop.open{opacity:1;pointer-events:auto;}" +
+      ".full-scrubber-drawer{position:fixed;left:0;right:0;bottom:0;z-index:1050;height:66vh;max-height:66vh;display:flex;flex-direction:column;overflow:hidden;background:#202b33;border-top:1px solid #394b59;border-radius:.5rem .5rem 0 0;box-shadow:0 -4px 16px rgba(0,0,0,.35);transform:translateY(105%);transition:transform .25s ease;}" +
+      ".full-scrubber-drawer.open{transform:translateY(0);}" +
+      ".full-scrubber-drawer.maximized{height:100vh;height:100dvh;max-height:100vh;max-height:100dvh;border-radius:0;}" +
+      ".full-scrubber-drawer.sidebar-section{border-bottom:none;}" +
+      ".full-scrubber-drawer .collapse-header{padding:0;}" +
+      ".full-scrubber-drawer .collapse,.full-scrubber-drawer .collapsing{padding-top:0;}" +
+      ".full-scrubber-drawer .collapse-button{display:inline-flex;align-items:center;gap:.35rem;padding:.55rem 1rem;border-radius:.25rem;}" +
+      ".full-scrubber-drawer .full-scrubber-sizes{display:flex;justify-content:space-between;align-items:center;margin-top:.5rem;padding:0 .5rem;}" +
+      ".full-scrubber-drawer .full-scrubber-size-control{display:flex;align-items:center;gap:.5rem;}" +
+      ".full-scrubber-drawer .full-scrubber-content{flex:1 1 auto;min-height:0;overflow-y:auto;margin-top:.5rem;padding-bottom:2rem;}" +
+      ".full-scrubber-tiles{display:flex;flex-wrap:wrap;gap:2px;justify-content:flex-start;overflow-y:auto;padding:0 .5rem .5rem;}";
+    document.head.appendChild(s);
+  }
+
+  function buildHeader() {
+    const head = document.createElement("div");
+    head.className = "collapse-header";
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "minimal collapse-button";
+    btn.title = "Close";
+    const icon = document.createElement("span");
+    icon.innerHTML = svgChevron(CHEV_DOWN, "chevron-down");
+    const label = document.createElement("span");
+    label.textContent = "Scene Thumbnails";
+    btn.appendChild(icon);
+    btn.appendChild(label);
+    btn.addEventListener("click", (e) => {
+      e.preventDefault();
+      closeDrawer();
+    });
+    head.appendChild(btn);
+    return head;
+  }
+
+  function buildBackdrop() {
+    if (backdropEl && backdropEl.isConnected) return;
+    const b = document.createElement("div");
+    b.className = "full-scrubber-backdrop";
+    b.addEventListener("click", closeDrawer);
+    document.body.appendChild(b);
+    backdropEl = b;
+  }
+
+  function buildToggle(ref) {
+    if (toggleEl && toggleEl.isConnected) return;
+    const wrap = document.createElement("div");
+    wrap.className = "full-scrubber-toggle-wrap";
+    if (ref) {
+      const cs = window.getComputedStyle(ref);
+      const mt = parseFloat(cs.marginTop) || 0;
+      const ml = parseFloat(cs.marginLeft) || 0;
+      const mr = parseFloat(cs.marginRight) || 0;
+      const hidden = !document.querySelector(".scrubber-wrapper");
+      const side = hidden ? 5 : ml;
+      wrap.style.marginLeft = side + "px";
+      wrap.style.marginRight = (hidden ? 5 : mr) + "px";
+      wrap.style.marginTop = (hidden ? 5 : Math.max(0, mt - (parseFloat(cs.marginBottom) || 0))) + "px";
+      let pb = (parseFloat(cs.marginBottom) || 0);
+      if (ref.parentNode) {
+        pb += parseFloat(window.getComputedStyle(ref.parentNode).paddingBottom) || 0;
+      }
+      wrap.style.marginBottom = Math.max(0, mt - pb) + "px";
+    }
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "full-scrubber-toggle";
+    btn.innerHTML = ICON_FILM + '<span class="full-scrubber-toggle-label">Scene Thumbnails</span>';
+    btn.addEventListener("click", (e) => {
+      e.preventDefault();
+      toggleDrawer();
+    });
+    wrap.appendChild(btn);
+    insertAfter(wrap, ref);
+    toggleEl = btn;
+    updateToggle();
+  }
+
+  function buildSizes() {
+    const wrap = document.createElement("div");
+    wrap.className = "full-scrubber-sizes";
+
+    const control = document.createElement("div");
+    control.className = "full-scrubber-size-control";
+    control.style.justifyContent = "flex-end";
+
+    const isMobile = window.matchMedia("(max-width: 768px)").matches;
+    let input;
+    if (isMobile) {
+      input = document.createElement("select");
+      input.className = "btn-secondary form-control";
+      input.style.width = "120px";
+      input.setAttribute("aria-label", "Thumbnails per row");
+      COL_OPTIONS.forEach((cols, i) => {
+        const opt = document.createElement("option");
+        opt.value = String(i);
+        opt.textContent = `${cols} per row`;
+        input.appendChild(opt);
+      });
+      updateSizeSelect(input);
+      input.addEventListener("change", () => {
+        const v = parseInt(input.value, 10);
+        const n = isNaN(v) ? 2 : Math.max(0, Math.min(COL_OPTION_COUNT - 1, v));
+        setColsPerRow(n);
+      });
+      control.appendChild(input);
+    } else {
+      input = document.createElement("input");
+      input.type = "range";
+      input.min = "0";
+      input.max = String(COL_OPTION_COUNT - 1);
+      input.step = "1";
+      input.className = "zoom-slider";
+      input.setAttribute("aria-label", "Thumbnails per row");
+      updateSizeInput(input);
+      input.addEventListener("input", () => {
+        const v = parseInt(input.value, 10);
+        const n = isNaN(v) ? 2 : Math.max(0, Math.min(COL_OPTION_COUNT - 1, v));
+        setColsPerRow(n);
+      });
+      control.appendChild(input);
+    }
+
+    wrap.appendChild(control);
+
+    const maxBtn = document.createElement("button");
+    maxBtn.type = "button";
+    maxBtn.className = "btn btn-secondary btn-sm full-scrubber-maximize";
+    maxBtn.title = "Maximize";
+    maxBtn.innerHTML = svgIcon(ICON_EXPAND, "expand", "0 0 448 512");
+    maxBtn.addEventListener("click", (e) => {
+      e.preventDefault();
+      toggleMaximize();
+    });
+    wrap.appendChild(maxBtn);
+
+    return wrap;
+  }
+
+  function updateSizeInput(input) {
+    input.value = String(colIndex);
+  }
+
+  function updateSizeSelect(select) {
+    select.value = String(colIndex);
+  }
+
+  function toggleMaximize() {
+    drawerMaximized = !drawerMaximized;
+    if (drawerEl) drawerEl.classList.toggle("maximized", drawerMaximized);
+    if (sizesEl) {
+      const btn = sizesEl.querySelector(".full-scrubber-maximize");
+      if (btn) {
+        btn.title = drawerMaximized ? "Restore" : "Maximize";
+        btn.innerHTML = svgIcon(
+          drawerMaximized ? ICON_COMPRESS : ICON_EXPAND,
+          drawerMaximized ? "compress" : "expand",
+          "0 0 448 512"
+        );
+      }
+    }
+  }
+
+  function setColsPerRow(n) {
+    if (n === colIndex) return;
+    colIndex = n;
+    try {
+      localStorage.setItem("sceneThumbnails.colsPerRow", String(COL_OPTIONS[colIndex]));
+    } catch (e) { }
+    if (sizesEl) {
+      const input = sizesEl.querySelector("input[type=range], select.btn-secondary.form-control");
+      if (input) {
+        if (input.tagName === "SELECT") updateSizeSelect(input);
+        else updateSizeInput(input);
+      }
+    }
+    renderTiles();
+  }
+
+  function renderTiles() {
+    if (!drawerTiles || !scrubberData) return;
+    tileSets = [];
+    drawerTiles.innerHTML = "";
+    buildTiles(drawerTiles, scrubberData);
+  }
+
+  function scrollToHighlight() {
+    if (!drawerContent) return;
+    const scroller = drawerContent;
+    let tile = null;
+    for (const set of tileSets) {
+      if (set.highlighted != null && set.tiles[set.highlighted]) {
+        tile = set.tiles[set.highlighted];
+        break;
+      }
+    }
+    if (!tile) return;
+    const cr = scroller.getBoundingClientRect();
+    const tr = tile.getBoundingClientRect();
+    scroller.scrollTop += tr.top - cr.top - (cr.height - tr.height) / 2;
+    scroller.scrollLeft += tr.left - cr.left - (cr.width - tr.width) / 2;
+  }
+
+  function openDrawer() {
+    drawerOpen = true;
+    if (drawerEl) drawerEl.classList.add("open");
+    if (backdropEl) backdropEl.classList.add("open");
+    updateToggle();
+    updateHighlight(lastVideoTime);
+    renderTiles();
+    scrollToHighlight();
+  }
+
+  function closeDrawer() {
+    drawerOpen = false;
+    if (drawerEl) drawerEl.classList.remove("open");
+    if (backdropEl) backdropEl.classList.remove("open");
+    updateToggle();
+  }
+
+  function toggleDrawer() {
+    if (drawerOpen) closeDrawer();
+    else openDrawer();
+  }
+
+  function updateToggle() {
+    if (!toggleEl) return;
+    const label = toggleEl.querySelector(".full-scrubber-toggle-label");
+    if (!label) return;
+    label.textContent = drawerOpen ? "Hide Scene Thumbnails" : "Scene Thumbnails";
+  }
+
+  function buildDrawer(id, data) {
+    if (drawerEl && drawerEl.isConnected) return;
+    ensureStyles();
+    buildBackdrop();
+
+    const drawer = document.createElement("div");
+    drawer.id = "full-scrubber-drawer";
+    drawer.className = "sidebar-section full-scrubber-drawer";
+
+    const content = document.createElement("div");
+    content.className = "collapse show full-scrubber-content";
+
+    const tiles = document.createElement("div");
+    tiles.className = "full-scrubber-tiles";
+    content.appendChild(tiles);
+
+    drawer.appendChild(buildHeader());
+    sizesEl = buildSizes();
+    drawer.appendChild(sizesEl);
+    drawer.appendChild(content);
+    document.body.appendChild(drawer);
+
+    drawerEl = drawer;
+    drawerTiles = tiles;
+    drawerContent = content;
+    buildTiles(tiles, data);
+  }
+
+  function teardown() {
+    if (toggleEl) {
+      try {
+        toggleEl.remove();
+      } catch (e) { }
+    }
+    toggleEl = null;
+    if (drawerEl) {
+      try {
+        drawerEl.remove();
+      } catch (e) { }
+    }
+    drawerEl = null;
+    drawerTiles = null;
+    drawerContent = null;
+    sizesEl = null;
+    drawerOpen = false;
+    if (backdropEl) {
+      try {
+        backdropEl.remove();
+      } catch (e) { }
+    }
+    backdropEl = null;
+    tileSets = [];
+    if (syncTimer) {
+      clearInterval(syncTimer);
+      syncTimer = null;
+    }
+    if (currentVideo) {
+      currentVideo.removeEventListener("timeupdate", onTime);
+      currentVideo.removeEventListener("seeked", onTime);
+      currentVideo.removeEventListener("loadedmetadata", onTime);
+      currentVideo.removeEventListener("durationchange", onTime);
+      currentVideo.removeEventListener("play", onTime);
+      currentVideo = null;
+    }
+  }
+
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape" && drawerOpen) closeDrawer();
+  });
+
+  let lastIsMobile = window.matchMedia("(max-width: 768px)").matches;
+
+  function onResize() {
+    if (drawerOpen) {
+      renderTiles();
+      const isMobile = window.matchMedia("(max-width: 768px)").matches;
+      if (isMobile !== lastIsMobile) {
+        lastIsMobile = isMobile;
+        if (sizesEl && sizesEl.parentNode) {
+          const newControl = buildSizes();
+          sizesEl.replaceWith(newControl);
+          sizesEl = newControl;
+        }
+      }
+    }
+  }
+  window.addEventListener("resize", onResize);
+
+  function init() {
+    const m = location.pathname.match(IDRE);
+    if (!m) {
+      teardown();
+      return;
+    }
+    const id = m[1];
+
+    const playerEl = document.querySelector(".video-js");
+    if (!playerEl) return;
+
+    if (scrubberFor !== id) {
+      teardown();
+      scrubberFor = id;
+    }
+
+    const video = playerEl.querySelector("video") || playerEl.querySelector(".vjs-tech");
+    attachListeners(video);
+
+    getData(id).then((data) => {
+      if (!data) return;
+      const anchor =
+        document.querySelector(".scrubber-wrapper") ||
+        document.querySelector(".video-wrapper") ||
+        document.querySelector(".video-js");
+      buildToggle(anchor);
+      buildDrawer(id, data);
+    });
+  }
+
+  let timer = null;
+  function schedule() {
+    if (timer) return;
+    timer = setTimeout(() => {
+      timer = null;
+      init();
+    }, 100);
+  }
+
+  const obs = new MutationObserver(schedule);
+  obs.observe(document.documentElement, { childList: true, subtree: true });
+  schedule();
+})();

--- a/plugins/SceneThumbnails/SceneThumbnails.yml
+++ b/plugins/SceneThumbnails/SceneThumbnails.yml
@@ -1,0 +1,7 @@
+---
+description: Scene Thumbnails adds a dismissable thumbnail grid built in the browser from Stash's existing scene sprite, shown in a drawer at the bottom of the scene panel, with a live highlight that follows playback and thumbnail-size and full-height toggles.
+name: Scene Thumbnails
+ui:
+  javascript:
+    - SceneThumbnails.js
+version: 0.0.1


### PR DESCRIPTION
Adds a dismissable thumbnail grid to Stash scene pages, built entirely in the browser from Stash's existing scene sprite and WebVTT — no generation, no ffmpeg, nothing written to disk. Clicking a tile seeks playback; a live highlight follows the current playing position; a slider adjusts thumbnails per row (1, 2, 3, 4, 6, 12) and a toggle maximizes the drawer. The only thing persisted is your grid-size preference, kept in the browser (localStorage).

### Files
- plugins/SceneThumbnails/SceneThumbnails.yml
- plugins/SceneThumbnails/SceneThumbnails.js
- plugins/SceneThumbnails/README.md
- plugins/SceneThumbnails/LICENSE


### Validation
passes the repo validator (node ./validate.js --ci).


### License / provenance
AGPL-3.0. The scene-sprite/WebVTT data pipeline is derived from Mosaic Poster (https://discourse.stashapp.cc/t/mosaic-poster/12358) (also AGPL, part of this repo); attribution is preserved in the file header and README.


### LLM-assisted contribution
This was developed with assistance from an LLM, per the repo's LLM contribution policy. The code has been reviewed by a human, tested against a local Stash instance, and validated with the repo's validator. I take full responsibility for the code and license compliance.


### Screenshots

**Scene Thumbnails button below the scrubber**
<img width="1022" height="424" alt="Scene Thumbnails button" src="https://github.com/user-attachments/assets/298ef02c-6c06-4ed9-b393-9bb8f78e9a2f" />

**Expanded drawer with adjustable thumbnail grid**
<img width="1382" height="679" alt="Expanded thumbnail drawer" src="https://github.com/user-attachments/assets/15eff89f-3434-47d7-ba67-99f08d007d1c" />

**Mobile**
<img width="490" height="692" alt="Mobile layout" src="https://github.com/user-attachments/assets/b9289ba3-191f-415e-8f0d-8c1c7c401a65" />
