### PR TITLE
AudioPlayerLite: fix 'originalComponent is not a function' on the second scene opened

### DIFF
--- a/plugins/AudioPlayerLite/AudioPlayerLite.js
+++ b/plugins/AudioPlayerLite/AudioPlayerLite.js
@@ -12,24 +12,35 @@
         }
     }
 
+    // patch.instead() appends to a list of patches, so registering on every
+    // navigation stacks up copies of this patch and breaks the patch chain.
+    let patched = false;
+
     PluginApi.Event.addEventListener("stash:location", async (e) => {
+        if (patched) return;
+
         const path = e.detail.data.location.pathname;
         const idRegExp = /.*\/scenes\/(\d+)/;
-        if (idRegExp.test(path)) {
-            await PluginApi.utils.loadComponents([
-                PluginApi.loadableComponents.ScenePlayer
-            ]);
-            PluginApi.patch.instead("ScenePlayer", function (props, _, originalComponent) {
-                const file = props.scene.files[0];
-                let scene = props.scene;
-                if (file.video_codec === "") {
-                    scene = { ...scene,
-                        sceneStreams: props.scene.sceneStreams.filter((ss) => ss.label.toUpperCase() === 'HSL')
-                    };
-                    poster()
-                }
-                return originalComponent({ ...props, scene });
-            });
-        }
+        if (!idRegExp.test(path)) return;
+
+        await PluginApi.utils.loadComponents([
+            PluginApi.loadableComponents.ScenePlayer
+        ]);
+
+        // re-check: another navigation event may have been handled while awaiting
+        if (patched) return;
+        patched = true;
+
+        PluginApi.patch.instead("ScenePlayer", function (props, _, originalComponent) {
+            const file = props.scene && props.scene.files && props.scene.files[0];
+            let scene = props.scene;
+            if (file && file.video_codec === "") {
+                scene = { ...scene,
+                    sceneStreams: props.scene.sceneStreams.filter((ss) => ss.label.toUpperCase() === 'HSL')
+                };
+                setStyle()
+            }
+            return React.createElement(originalComponent, { ...props, scene });
+        });
     });
 })();

--- a/plugins/AudioPlayerLite/AudioPlayerLite.yml
+++ b/plugins/AudioPlayerLite/AudioPlayerLite.yml
@@ -1,6 +1,6 @@
 name: AudioPlayerLite
 description: This plugin identifies files with no video codec and plays them as audio.
-version: 0.1
+version: 0.2
 url: https://discourse.stashapp.cc/t/audioplayerlite/1329
 ui:
   javascript:


### PR DESCRIPTION
### The bug

Opening a scene works right after a page load, but every scene opened afterwards (without reloading) fails with the generic "Something went wrong." page:

```
TypeError: originalComponent is not a function
    at Object.apply (assets/index-*.js)
    ...
    at jt (assets/Scene-*.js)
```

Reloading the page makes it work again — once.

### Cause

The plugin registers its patch inside the `stash:location` handler, so every navigation to `/scenes/<id>` pushes another copy of the same function onto `insteadFns["ScenePlayer"]` — `patch.instead()` only appends, it never deduplicates.

Once there is more than one patch in the chain, `runInstead()` (`ui/v2.5/src/patch.tsx`) hands each patch the next one as a trailing argument:

```js
return fns[0].apply(thisArg, argArray.concat(next()));
// next() returns a Proxy: apply: (target, ctx, args) => target.apply(ctx, args.concat(next()))
```

React calls a function component as `(props, secondArg)`, which is why the first patch correctly receives the original as its third argument. But the plugin invokes it as `originalComponent({ ...props, scene })` — a single argument — so the proxy passes `(props, next)` to the second copy. There the original component lands in the second parameter and the third one is `undefined`, hence `originalComponent is not a function`, thrown from the proxy's `apply` trap.

### The fix

- Register the patch only once per page load.
- Render the original through `React.createElement(originalComponent, ...)` instead of calling it with one argument, so the chain still works if another plugin patches `ScenePlayer` as well.
- Call `setStyle()` instead of `poster()`, which is not defined anywhere in the file and would throw a `ReferenceError` as soon as an actual audio file was opened.
- Guard `props.scene.files[0]` against scenes with no files.
- Version bumped 0.1 → 0.2 so existing installs pick the fix up.

### Testing

The patched file is deployed on my own instance, where this error was breaking scene playback regularly. `node ./validate.js --ci` passes.

### Disclosure

The patch was drafted with LLM assistance; I reviewed it and tested it on my own instance, and I take responsibility for the code.
