### PR TITLE
DupFileManager, FileMonitor, RenameFile: bind the exception in retry handlers

### DIFF
--- a/plugins/DupFileManager/DupFileManager.py
+++ b/plugins/DupFileManager/DupFileManager.py
@@ -348,7 +348,7 @@ def setTagId_withRetry(tagName, sceneDetails, DupFileToKeep, TagReason="", ignor
             if errMsg != None:
                 stash.Warn(errMsg)
             return setTagId(tagName, sceneDetails, DupFileToKeep, TagReason, ignoreAutoTag)
-        except (requests.exceptions.ConnectionError, ConnectionResetError):
+        except (requests.exceptions.ConnectionError, ConnectionResetError) as e:
             tb = traceback.format_exc()
             errMsg = f"[setTagId] Exception calling setTagId. Will retry; count({i}); Error: {e}\nTraceBack={tb}"
         except Exception as e:

--- a/plugins/DupFileManager/StashPluginHelper.py
+++ b/plugins/DupFileManager/StashPluginHelper.py
@@ -519,7 +519,7 @@ class StashPluginHelper(StashInterface):
                     SrcData = self.find_scene(SrcData)
                     DestData = self.find_scene(DestData)
                 return self._mergeMetadata.merge(SrcData, DestData)
-            except (requests.exceptions.ConnectionError, ConnectionResetError):
+            except (requests.exceptions.ConnectionError, ConnectionResetError) as e:
                 tb = traceback.format_exc()
                 errMsg = f"Exception calling [mergeMetadata]. Will retry; count({i}); Error: {e}\nTraceBack={tb}"
             except Exception as e:
@@ -710,7 +710,7 @@ class StashPluginHelper(StashInterface):
                 dataDict.update({'tag_ids' : tagIds})
                 self.update_scene(dataDict)
                 return True
-            except (ConnectionResetError):
+            except (ConnectionResetError) as e:
                 tb = traceback.format_exc()
                 errMsg = f"Exception calling [addTag]. Will retry; count({i}); Error: {e}\nTraceBack={tb}"
             except Exception as e:
@@ -745,7 +745,7 @@ class StashPluginHelper(StashInterface):
                 if errMsg != None:
                     self.Warn(errMsg)
                 return self.update_scene(update_input, create)
-            except (ConnectionResetError):
+            except (ConnectionResetError) as e:
                 tb = traceback.format_exc()
                 errMsg = f"Exception calling [updateScene]. Will retry; count({i}); Error: {e}\nTraceBack={tb}"
             except Exception as e:
@@ -766,7 +766,7 @@ class StashPluginHelper(StashInterface):
                         self.Warn(f"Scene {scene_id} not found in Stash.")
                         return False
                 return self.destroy_scene(scene_id, delete_file)
-            except (ConnectionResetError):
+            except (ConnectionResetError) as e:
                 tb = traceback.format_exc()
                 errMsg = f"Exception calling [updateScene]. Will retry; count({i}); Error: {e}\nTraceBack={tb}"
             except Exception as e:

--- a/plugins/FileMonitor/StashPluginHelper.py
+++ b/plugins/FileMonitor/StashPluginHelper.py
@@ -519,7 +519,7 @@ class StashPluginHelper(StashInterface):
                     SrcData = self.find_scene(SrcData)
                     DestData = self.find_scene(DestData)
                 return self._mergeMetadata.merge(SrcData, DestData)
-            except (requests.exceptions.ConnectionError, ConnectionResetError):
+            except (requests.exceptions.ConnectionError, ConnectionResetError) as e:
                 tb = traceback.format_exc()
                 errMsg = f"Exception calling [mergeMetadata]. Will retry; count({i}); Error: {e}\nTraceBack={tb}"
             except Exception as e:
@@ -710,7 +710,7 @@ class StashPluginHelper(StashInterface):
                 dataDict.update({'tag_ids' : tagIds})
                 self.update_scene(dataDict)
                 return True
-            except (ConnectionResetError):
+            except (ConnectionResetError) as e:
                 tb = traceback.format_exc()
                 errMsg = f"Exception calling [addTag]. Will retry; count({i}); Error: {e}\nTraceBack={tb}"
             except Exception as e:
@@ -745,7 +745,7 @@ class StashPluginHelper(StashInterface):
                 if errMsg != None:
                     self.Warn(errMsg)
                 return self.update_scene(update_input, create)
-            except (ConnectionResetError):
+            except (ConnectionResetError) as e:
                 tb = traceback.format_exc()
                 errMsg = f"Exception calling [updateScene]. Will retry; count({i}); Error: {e}\nTraceBack={tb}"
             except Exception as e:
@@ -766,7 +766,7 @@ class StashPluginHelper(StashInterface):
                         self.Warn(f"Scene {scene_id} not found in Stash.")
                         return False
                 return self.destroy_scene(scene_id, delete_file)
-            except (ConnectionResetError):
+            except (ConnectionResetError) as e:
                 tb = traceback.format_exc()
                 errMsg = f"Exception calling [updateScene]. Will retry; count({i}); Error: {e}\nTraceBack={tb}"
             except Exception as e:

--- a/plugins/RenameFile/StashPluginHelper.py
+++ b/plugins/RenameFile/StashPluginHelper.py
@@ -519,7 +519,7 @@ class StashPluginHelper(StashInterface):
                     SrcData = self.find_scene(SrcData)
                     DestData = self.find_scene(DestData)
                 return self._mergeMetadata.merge(SrcData, DestData)
-            except (requests.exceptions.ConnectionError, ConnectionResetError):
+            except (requests.exceptions.ConnectionError, ConnectionResetError) as e:
                 tb = traceback.format_exc()
                 errMsg = f"Exception calling [mergeMetadata]. Will retry; count({i}); Error: {e}\nTraceBack={tb}"
             except Exception as e:
@@ -710,7 +710,7 @@ class StashPluginHelper(StashInterface):
                 dataDict.update({'tag_ids' : tagIds})
                 self.update_scene(dataDict)
                 return True
-            except (ConnectionResetError):
+            except (ConnectionResetError) as e:
                 tb = traceback.format_exc()
                 errMsg = f"Exception calling [addTag]. Will retry; count({i}); Error: {e}\nTraceBack={tb}"
             except Exception as e:
@@ -745,7 +745,7 @@ class StashPluginHelper(StashInterface):
                 if errMsg != None:
                     self.Warn(errMsg)
                 return self.update_scene(update_input, create)
-            except (ConnectionResetError):
+            except (ConnectionResetError) as e:
                 tb = traceback.format_exc()
                 errMsg = f"Exception calling [updateScene]. Will retry; count({i}); Error: {e}\nTraceBack={tb}"
             except Exception as e:
@@ -766,7 +766,7 @@ class StashPluginHelper(StashInterface):
                         self.Warn(f"Scene {scene_id} not found in Stash.")
                         return False
                 return self.destroy_scene(scene_id, delete_file)
-            except (ConnectionResetError):
+            except (ConnectionResetError) as e:
                 tb = traceback.format_exc()
                 errMsg = f"Exception calling [updateScene]. Will retry; count({i}); Error: {e}\nTraceBack={tb}"
             except Exception as e:


### PR DESCRIPTION
### The problem

Each retry loop in `StashPluginHelper.py` has two exception handlers: a narrow one for connection errors, and a broad one for everything else. Both build the same log message including `{e}` — but only the broad handler binds the name with `as e`.

Because the sibling handler binds `e` as a function local, the narrow handler raises `UnboundLocalError` while formatting its own log message. That propagates out of the retry loop, so a dropped connection — the exact condition the loop exists to survive — aborts the operation on the first failure and reports the wrong error.

Reproduction, matching the structure in the source:

```python
def retry():
    for i in range(3):
        try:
            raise ConnectionResetError("connection dropped")
        except (ConnectionResetError):
            print(f"retrying: {e}")     # UnboundLocalError
        except Exception as e:
            print(f"retrying: {e}")
```

### Scope

13 sites across the three plugins that vendor `StashPluginHelper.py`:

| File | Lines |
|---|---|
| `plugins/DupFileManager/StashPluginHelper.py` | 522, 713, 748, 769 |
| `plugins/FileMonitor/StashPluginHelper.py` | 522, 713, 748, 769 |
| `plugins/RenameFile/StashPluginHelper.py` | 522, 713, 748, 769 |
| `plugins/DupFileManager/DupFileManager.py` | 351 |

Those are the `mergeMetadata`, `addTag`, `updateScene` and `destroyScene` retry loops in each copy of the helper, plus `setTagId_withRetry` in DupFileManager.

Every change is the same one-token edit — adding `as e` to a handler that already interpolated `e`. No behaviour changes beyond the retry path now working as written.

### Testing

Tested against a clean Stash **v0.31.1** instance in Docker with a two-scene library, driving the plugin helper through the real plugin entry path (plugin JSON on stdin, `server_connection` context).

Fault injection: `mergeMetadata` was made to raise `ConnectionResetError` on its first two attempts, then succeed — the scenario the retry loop is written for. Same test run against both the current `main` and this branch:

```
RESULT[original]: UnboundLocalError: cannot access local variable 'e'
                  where it is not associated with a value   (attempts = 1)
RESULT[patched]:  survived the resets and completed;        attempts = 3
```

`main` aborts on the first reset. With the fix, the loop retries and completes as intended.

Also confirmed:

- A normal (non-failing) `mergeMetadata` between two scenes behaves identically before and after — no regression in the success path.
- AST pass over the whole repository: zero remaining `except` handlers that reference an unbound `e`.
- All four modified files compile.

`plugins/starIdentifier/star_identifier.py` matches this pattern at first glance but is **not** affected — `load_encodings()` binds `e = Exception(...)` before the `try`, so its handler resolves the name from the enclosing scope. Deliberately left alone.

### Note for maintainers

`StashPluginHelper.py` is vendored into three plugins and the copies have already drifted — DupFileManager's differs from the other two. This fix is applied to all three. Worth considering whether that file wants a single shared home.

### LLM-assisted contribution disclosure

Per the repository's contribution policy: this change was prepared with LLM assistance (Claude). The diff has been reviewed by me, the testing described above was carried out and its results are reproduced verbatim, and I take full responsibility for the change and its license compliance.
