### PR TITLE
BulkImageScrape: fix `CreateMissingTags` setting

### DIFF
--- a/plugins/bulkImageScrape/BulkImageScrape.yml
+++ b/plugins/bulkImageScrape/BulkImageScrape.yml
@@ -1,7 +1,7 @@
 name: Bulk Image Scrape
 # requires: PythonDepManager 
 description: Apply an image scraper to all images
-version: 0.3.4
+version: 0.3.5
 url: https://discourse.stashapp.cc/t/bulk-image-scrape/1339
 exec:
   - python

--- a/plugins/bulkImageScrape/BulkImageScrape.yml
+++ b/plugins/bulkImageScrape/BulkImageScrape.yml
@@ -21,8 +21,8 @@ settings:
   CreateMissingStudios:
     displayName: Create missing studios from scrape result
     type: BOOLEAN
-  CreateMissingMovies:
-    displayName: Create missing movies/groups from scrape result
+  CreateMissingTags:
+    displayName: Create missing tags from scrape result
     type: BOOLEAN
   MergeExistingTags:
     displayName: Merge existing tags with the scraped tags (default is to overwrite)

--- a/plugins/bulkImageScrape/README.md
+++ b/plugins/bulkImageScrape/README.md
@@ -16,9 +16,9 @@ It is mandatory to enter the Scraper ID of the Scraper you want to use. In this 
 
 ![Settings](./res/settings.png)
 
-- `Create Missing movies/groups from scrape result`
+- `Create Missing tags from scrape result`
 
-> If the scraper returns a movie/group and it is not already in your stash, the plugin will create it if enabled
+> If the scraper returns a tag and it is not already in your stash, the plugin will create it if enabled
 
 - `Create Missing performer from scrape result`
 


### PR DESCRIPTION
The plugin code itself handles the `CreateMissingTags`, but it's not declared in the YAML file.
Also, `CreateMissingMovies` makes no sense for images, it's for scenes.