### PR TITLE
BulkImageScrape: enable `force_api_key`

### DIFF
--- a/plugins/bulkImageScrape/BulkImageScrape.yml
+++ b/plugins/bulkImageScrape/BulkImageScrape.yml
@@ -1,7 +1,7 @@
 name: Bulk Image Scrape
 # requires: PythonDepManager 
 description: Apply an image scraper to all images
-version: 0.3.5
+version: 0.3.6
 url: https://discourse.stashapp.cc/t/bulk-image-scrape/1339
 exec:
   - python

--- a/plugins/bulkImageScrape/bulkImageScrape.py
+++ b/plugins/bulkImageScrape/bulkImageScrape.py
@@ -292,7 +292,7 @@ def update_image(client: StashInterface, update: dict) -> dict | None:
 
 json_input: dict = json.loads(sys.stdin.read())
 FRAGMENT_SERVER: dict = json_input["server_connection"]
-stash: StashInterface = StashInterface(FRAGMENT_SERVER)
+stash: StashInterface = StashInterface(FRAGMENT_SERVER, force_api_key=True)
 log.info("Starting Bulk Image Scrape Plugin")
 
 config: dict = stash.get_configuration()["plugins"]


### PR DESCRIPTION
During long bulk image scraping tasks the session cookie can time out. This leads to tons of authentication errors and the plugin stops somewhere half-way in the middle.

I expected this to be unnecessary because stashapi is supposed to use the `ApiKey`, but Stash itself actually never passes it: https://github.com/stg-annon/stashapi/issues/34.
Enabling `force_api_key` makes stashapi look up the `ApiKey` using the session cookie and continue using that (if it's generated).

~~I haven't tested yet if this actually works. I should find out soon.~~ It seems to work.