### PR TITLE
fix(RenameFile): fix doubled file extension causing 'File name too long' error

### DIFF
--- a/plugins/RenameFile/renamefile.py
+++ b/plugins/RenameFile/renamefile.py
@@ -388,12 +388,12 @@ def rename_scene(scene_id):
     original_file_name  = Path(original_file_path).name
     new_filename        = form_filename(original_file_stem, scene_details)  
     max_filename_length = int(config["max_filename_length"])
-    if len(new_filename) > max_filename_length:
-        extension_length = len(Path(original_file_path).suffix)
-        max_base_filename_length = max_filename_length - extension_length
-        truncated_filename = new_filename[:max_base_filename_length]
+    extension_length = len(Path(original_file_path).suffix)
+    if len(new_filename) + extension_length > max_filename_length:
         hash_suffix = hashlib.md5(new_filename.encode()).hexdigest()
-        new_filename = truncated_filename + '_' + hash_suffix + Path(original_file_path).suffix
+        max_base_filename_length = max_filename_length - extension_length - len(hash_suffix) - 1
+        truncated_filename = new_filename[:max_base_filename_length]
+        new_filename = truncated_filename + '_' + hash_suffix
     newFilenameWithExt  = new_filename + Path(original_file_path).suffix
     new_file_path       = f"{original_parent_directory}{os.sep}{new_filename}{Path(original_file_name).suffix}"
     org_file_root_stem  = f"{original_parent_directory}{os.sep}{original_file_stem}"

--- a/plugins/RenameFile/renamefile.py
+++ b/plugins/RenameFile/renamefile.py
@@ -444,15 +444,15 @@ def rename_scene(scene_id):
             stash.Trace(f"Calling [metadata_scan] for path {original_parent_directory.resolve().as_posix()}")
             stash.metadata_scan(paths=[original_parent_directory.resolve().as_posix()])
         if targetDidExist:
-            raise
+            return None
         if os.path.isfile(new_file_path):
             if os.path.isfile(original_file_path):
                 os.remove(original_file_path)
             pass
         else:
             # ToDo: Add delay rename here
-            raise
-    
+            return None
+
     if dry_run:
         stash.Log("Dry-Run, so skipping DB renaming")
     elif stash.renameFileNameInDB(scene_details['files'][0]['id'], original_file_name, newFilenameWithExt):

--- a/plugins/RenameFile/renamefile.yml
+++ b/plugins/RenameFile/renamefile.yml
@@ -1,6 +1,6 @@
 name: RenameFile
 description: Renames video (scene) file names when the user edits the [Title] field located in the scene [Edit] tab.
-version: 1.0.1
+version: 1.0.3
 url: https://discourse.stashapp.cc/t/renamefile/1334
 ui:
   css:

--- a/plugins/RenameFile/version_history/README.md
+++ b/plugins/RenameFile/version_history/README.md
@@ -16,3 +16,6 @@
 - Fixed Dry-Run bug, which changed the file name in the database when Dry-Run was enabled.
 ### 1.0.1
 - 
+### 1.0.2
+- Fixed OSError "File name too long" (macOS) caused by the long-filename truncation logic appending the file extension twice and not reserving space for the hash suffix.
+- Rename/move failures now log a single clear error message instead of also dumping a raw Python traceback to the log.

--- a/plugins/RenameFile/version_history/README.md
+++ b/plugins/RenameFile/version_history/README.md
@@ -17,5 +17,7 @@
 ### 1.0.1
 - 
 ### 1.0.2
+- 
+### 1.0.3
 - Fixed OSError "File name too long" (macOS) caused by the long-filename truncation logic appending the file extension twice and not reserving space for the hash suffix.
 - Rename/move failures now log a single clear error message instead of also dumping a raw Python traceback to the log.


### PR DESCRIPTION
Fixes #767

**Independent of #733.** This branch was previously stacked on `fix/renamefile-title-stuck`; it has been rebased onto `main` and now contains only the `renamefile.py` changes described below. The two PRs no longer overlap and can be reviewed separately. Note the version number assumes #733 lands first — if this merges first, the bump here should be `1.0.2` instead.

### Summary
- Fix the long-filename truncation fallback in `RenameFile` so it no longer doubles the file extension and correctly reserves space for the hash suffix, which was causing `OSError: [Errno 63] File name too long` (macOS) / `ENAMETOOLONG` when renaming scenes whose formatted filename exceeded `max_filename_length`.
- When a rename/move does fail, stop the OSError from being re-raised into the top-level catch-all (which dumped a full Python traceback into the log on top of the already-logged clear error message).
- Bump plugin version to 1.0.3 and update the changelog.

### Root cause
See #767 for the full analysis. In short: the truncation branch built `new_filename` as `truncated + '_' + hash + extension`, but the length budget it truncated to only subtracted the extension length (not the `_`+hash), and the caller then appended the extension a second time (`newFilenameWithExt = new_filename + suffix`), producing filenames like `....mp4.mp4` well past `max_filename_length`.

### Testing
- Reproduced the exact reported failure by hand: recomputed the original 292-character doubled-extension filename from the logged error and confirmed the new logic instead produces a name at or under the configured `max_filename_length`, with a single extension.
- Ran the repo's plugin validator (`node ./validator/index.js --ci`) — passes.
- Not yet exercised against a live Stash instance with an actual over-long title/tag combination; recommend a maintainer or the reporter re-test the original scenario before merge.

### AI disclosure
This fix (analysis, code changes, issue text, and this PR description) was drafted with LLM (Claude) assistance from a real user-reported error log. The diff was reviewed by a human before submission, per the repo's LLM-assisted contribution policy.

